### PR TITLE
feat: Implement Advanced Hierarchical Chunking (AHC) Attention

### DIFF
--- a/my_attention_research_project/configs/base_ahc_config.yaml
+++ b/my_attention_research_project/configs/base_ahc_config.yaml
@@ -1,0 +1,67 @@
+# Base Configuration for Advanced Hierarchical Chunking (AHC)
+
+model:
+  # TransformerEncoder overall parameters (can be adjusted)
+  d_model: 512
+  num_encoder_layers: 6
+  ffn_dim_factor: 4 # d_ff = d_model * ffn_dim_factor
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+
+  # Attention specific configuration
+  attention:
+    type: "AHC"       # Specifies the AHC attention module
+    # dropout_rate: 0.1 # Dropout for attention mechanisms (can be same as global or specific)
+                        # If not specified here, AHCAttention will use TransformerEncoder's dropout_rate.
+
+    # AHCAttention specific parameters
+    n_heads: 8          # Number of heads for local MHA (and default for global if not specified in G1)
+    chunk_size: 64      # Size of chunks for local attention
+
+    summarization_method_config:
+      type: "S1_pool"   # Options: "S1_pool", "S2_linear_on_pool"
+      pool_type: "mean" # Options: "mean", "max" (applies to both S1 and S2's pooling stage)
+
+    # Example for S2_linear_on_pool:
+    # summarization_method_config:
+    #   type: "S2_linear_on_pool"
+    #   pool_type: "mean" 
+
+    global_attention_method_config:
+      type: "G1_full_mha" # Currently only G1_full_mha is implemented
+      num_heads: 8        # Number of heads for global MHA on summaries (can be same as local or different)
+      # dropout_rate: 0.1 # Optional: specific dropout for global MHA
+
+    combination_method_config:
+      type: "C1_broadcast_add" # Currently only C1_broadcast_add is implemented
+
+# Data configuration (example, can be same as base_mha_config.yaml)
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 512
+  batch_size: 32
+  data_dir: "./data/processed/wikitext-103"
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json"
+
+# Training configuration (example, can be same as base_mha_config.yaml)
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 10 # Adjust as needed
+  random_seed: 42
+  gradient_clipping: 1.0
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 1000
+    min_lr: 0.00001
+
+# Benchmarking specific settings
+benchmarking:
+  batch_size_inference: 64
+  perplexity_eval_sequence_lengths: [512, 1024, 2048] # Should be multiples of chunk_size for AHC
+
+# Logging
+logging:
+  log_level: "INFO"
+  log_file: "training_ahc.log"

--- a/my_attention_research_project/models/attention/__init__.py
+++ b/my_attention_research_project/models/attention/__init__.py
@@ -1,1 +1,13 @@
-# Placeholder for __init__.py
+from .vanilla_mha import MultiHeadAttention, ScaledDotProductAttention
+from .ahc_attention import AHCAttention
+from .moae_attention import MOAEAttention
+from .pas_attention import PASAttention
+
+# This line ensures that `from my_attention_research_project.models.attention import *`
+# would import all the above.
+__all__ = [
+    "MultiHeadAttention", "ScaledDotProductAttention",
+    "AHCAttention",
+    "MOAEAttention",
+    "PASAttention"
+]

--- a/my_attention_research_project/models/attention/ahc_attention.py
+++ b/my_attention_research_project/models/attention/ahc_attention.py
@@ -1,1 +1,277 @@
-# Placeholder for ahc_attention.py
+import torch
+import torch.nn as nn
+import torch.nn.functional as F # Added import for F.pad
+from .vanilla_mha import MultiHeadAttention # Used for local and potentially global attention
+
+class AHCAttention(nn.Module):
+    def __init__(self,
+                 d_model: int,
+                 n_heads: int, 
+                 chunk_size: int, 
+                 summarization_method_config: dict, 
+                 global_attention_method_config: dict, 
+                 combination_method_config: dict, 
+                 dropout_rate: float = 0.0,
+                 **kwargs): # Added **kwargs for flexibility
+        super().__init__()
+        self.d_model = d_model
+        self.n_heads = n_heads # For local MHA
+        self.chunk_size = chunk_size
+        self.summarization_method_config = summarization_method_config
+        self.global_attention_method_config = global_attention_method_config
+        self.combination_method_config = combination_method_config
+        self.dropout_rate = dropout_rate
+
+        # Store any additional kwargs if needed, or process them
+        # For example, these might contain specific parameters for summarization or global attention
+        # that are not explicitly listed in the signature but are passed via attention_config.
+        self.additional_config = kwargs
+
+        # Instantiate Local MHA
+        self.local_mha = MultiHeadAttention(
+            d_model=self.d_model,
+            n_heads=self.n_heads,
+            dropout_rate=self.dropout_rate
+        )
+
+        # Initialize Global MHA
+        self.global_mha = None
+        global_attention_type = self.global_attention_method_config.get('type')
+        if global_attention_type == "G1_full_mha":
+            global_n_heads = self.global_attention_method_config.get('num_heads', self.n_heads)
+            global_dropout_rate = self.global_attention_method_config.get('dropout_rate', self.dropout_rate)
+            self.global_mha = MultiHeadAttention(
+                d_model=self.d_model,
+                n_heads=global_n_heads,
+                dropout_rate=global_dropout_rate
+            )
+        elif global_attention_type is not None: # If a type is specified but not G1
+            raise NotImplementedError(f"Global attention type '{global_attention_type}' is not yet implemented.")
+
+        # Initialize Summarization-specific layers (e.g., for S2)
+        self.s2_linear_projection = None
+        if self.summarization_method_config.get('type') == "S2_linear_on_pool":
+            if not hasattr(self, '_summarize_s1_pool'): # Check if S1 is available for reuse
+                raise AttributeError("S2_linear_on_pool requires S1_pool's pooling logic. Ensure _summarize_s1_pool is defined.")
+            self.s2_linear_projection = nn.Linear(self.d_model, self.d_model)
+        
+        # Placeholder for other module instantiations (combination)
+        # e.g., Initialize combination layer based on combination_method_config
+
+    def _combine_c1_broadcast_add(self, local_context: torch.Tensor, global_context_summaries: torch.Tensor) -> torch.Tensor:
+        """
+        Combines local and global contexts using broadcast addition (C1).
+        Args:
+            local_context (torch.Tensor): Output of local attention.
+                                          Shape: (batch_size, num_chunks, chunk_size, d_model).
+            global_context_summaries (torch.Tensor): Processed summary tokens from global attention.
+                                                     Shape: (batch_size, num_chunks, d_model).
+        Returns:
+            torch.Tensor: Combined context. Shape: (batch_size, num_chunks, chunk_size, d_model).
+        """
+        # global_context_summaries is (B, N, D)
+        # We need to expand it to (B, N, C, D) to match local_context (B, N, C, D)
+        # C is self.chunk_size
+        expanded_global_context = global_context_summaries.unsqueeze(2).expand(-1, -1, self.chunk_size, -1)
+        combined_context = local_context + expanded_global_context
+        return combined_context
+
+    def _summarize_s1_pool(self, local_context: torch.Tensor, summarization_config: dict) -> torch.Tensor:
+        """
+        Performs pooling-based summarization (S1).
+        Args:
+            local_context (torch.Tensor): Output of local attention.
+                                          Shape: (batch_size, num_chunks, chunk_size, d_model).
+            summarization_config (dict): Configuration for summarization, containing 'pool_type'.
+
+        Returns:
+            torch.Tensor: Summary tokens. Shape: (batch_size, num_chunks, d_model).
+        """
+        pool_type = summarization_config.get('pool_type', 'mean') # Default to mean if not specified
+
+        if pool_type == 'mean':
+            summary_tokens = torch.mean(local_context, dim=2) # Pool over chunk_size dimension
+        elif pool_type == 'max':
+            summary_tokens = torch.max(local_context, dim=2).values # Pool over chunk_size dimension
+        else:
+            raise ValueError(f"Unsupported S1 pool_type: {pool_type}")
+        
+        return summary_tokens
+
+    def _summarize_s2_linear_on_pool(self, local_context: torch.Tensor, summarization_config: dict) -> torch.Tensor:
+        """
+        Performs S2 summarization (Linear projection on pooled tokens).
+        Args:
+            local_context (torch.Tensor): Output of local attention.
+                                          Shape: (batch_size, num_chunks, chunk_size, d_model).
+            summarization_config (dict): Configuration for summarization.
+                                         'pool_type' from this config is used by _summarize_s1_pool.
+        Returns:
+            torch.Tensor: Summary tokens. Shape: (batch_size, num_chunks, d_model).
+        """
+        # Reuse S1's pooling logic by calling it directly
+        pooled_tokens = self._summarize_s1_pool(local_context, summarization_config)
+        # pooled_tokens shape: (batch_size, num_chunks, d_model)
+
+        if self.s2_linear_projection is None:
+            raise RuntimeError("S2 linear projection layer is not initialized. Check configuration.")
+            
+        summary_tokens = self.s2_linear_projection(pooled_tokens)
+        return summary_tokens
+
+    def _chunk_input(self, x: torch.Tensor):
+        """
+        Pads and reshapes the input tensor into chunks.
+        Args:
+            x (torch.Tensor): Input tensor of shape (batch_size, seq_len, d_model).
+
+        Returns:
+            Tuple[torch.Tensor, int, int]:
+                - chunked_x (torch.Tensor): Reshaped tensor (batch_size, num_chunks, chunk_size, d_model).
+                - padding_needed (int): Amount of padding added.
+                - original_seq_len (int): Sequence length before padding.
+        """
+        batch_size, seq_len, d_model = x.shape
+        original_seq_len = seq_len
+
+        padding_needed = 0
+        if seq_len % self.chunk_size != 0:
+            padding_needed = self.chunk_size - (seq_len % self.chunk_size)
+            # Pad with zeros on the right (sequence dimension)
+            # F.pad format: (pad_left_dimN, pad_right_dimN, pad_left_dimN-1, pad_right_dimN-1, ...)
+            # For (B, S, D), we want to pad S (dim 1).
+            # So, (0,0) for d_model (last dim), and (0, padding_needed) for seq_len (2nd to last dim).
+            x = F.pad(x, (0, 0, 0, padding_needed))
+        
+        padded_seq_len = x.shape[1] # seq_len after padding
+        num_chunks = padded_seq_len // self.chunk_size
+
+        chunked_x = x.view(batch_size, num_chunks, self.chunk_size, d_model)
+        return chunked_x, padding_needed, original_seq_len
+
+    def forward(self, query: torch.Tensor, key: torch.Tensor, value: torch.Tensor, mask: torch.Tensor = None):
+        """
+        Forward pass for AHCAttention.
+        Args:
+            query (torch.Tensor): Query tensor. Shape: (batch_size, seq_len, d_model).
+            key (torch.Tensor): Key tensor. Shape: (batch_size, seq_len, d_model).
+            value (torch.Tensor): Value tensor. Shape: (batch_size, seq_len, d_model).
+            mask (torch.Tensor, optional): Attention mask. Its shape depends on the specific
+                                           attention mechanism and how it's applied (e.g., for
+                                           local MHA or global attention). Defaults to None.
+                                           Currently unused in this placeholder implementation.
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]:
+                - context_vector (torch.Tensor): The output of the attention mechanism.
+                                                 Shape: (batch_size, seq_len, d_model).
+                - attention_weights (torch.Tensor, optional): Attention weights. Shape varies.
+                                                              Can be None.
+        """
+        # Assuming query, key, value are the same for self-attention for now.
+        # This will change as AHC logic is built out.
+        # For now, operate on `query` as the primary input `x`.
+        # In a full Transformer, query, key, value might be different for cross-attention.
+        # For encoder self-attention, they are typically the same.
+        x = query
+        x = query # Assuming Q, K, V are same for self-attention
+        batch_size, original_seq_len, d_model = x.shape
+        device = x.device
+
+        # 1. Chunking
+        chunked_x, padding_needed, _ = self._chunk_input(x)
+        # chunked_x shape: (B, N, C, D) where N=num_chunks, C=chunk_size
+        # Store num_chunks for potential use, e.g. if not inferable from a tensor later
+        current_num_chunks = chunked_x.shape[1]
+
+
+        # 2. Local Attention
+        local_mha_input = chunked_x.contiguous().view(-1, self.chunk_size, d_model)
+        # Causal mask for local attention
+        sz_c = self.chunk_size
+        causal_mask_for_local_attn = torch.tril(torch.ones(sz_c, sz_c, device=device)).unsqueeze(0).unsqueeze(0)
+        
+        local_context_flat, _ = self.local_mha(local_mha_input, local_mha_input, local_mha_input, mask=causal_mask_for_local_attn)
+        local_context = local_context_flat.view(batch_size, current_num_chunks, self.chunk_size, d_model)
+        # local_context shape: (B, N, C, D)
+
+        # 3. Summarization
+        summary_tokens = None
+        summarization_type = self.summarization_method_config.get('type')
+        if summarization_type == "S1_pool":
+            summary_tokens = self._summarize_s1_pool(local_context, self.summarization_method_config)
+        elif summarization_type == "S2_linear_on_pool":
+            summary_tokens = self._summarize_s2_linear_on_pool(local_context, self.summarization_method_config)
+        elif summarization_type is None: # Explicitly check for None
+             raise ValueError("Summarization type not specified in summarization_method_config.")
+        else: # Handles any other unsupported type
+            raise ValueError(f"Unsupported summarization type: {summarization_type}")
+        # summary_tokens shape: (B, N, D)
+
+        # 4. Global Attention
+        global_context_summaries = None
+        global_attention_type = self.global_attention_method_config.get('type')
+
+        if self.global_mha and global_attention_type == "G1_full_mha":
+            if summary_tokens is None: 
+                raise ValueError("Summary tokens are None, cannot apply G1_full_mha global attention.")
+            
+            num_summary_tokens = summary_tokens.shape[1] # Should be current_num_chunks
+            global_causal_mask = torch.tril(torch.ones(num_summary_tokens, num_summary_tokens, device=device)).unsqueeze(0).unsqueeze(0)
+            global_context_summaries, _ = self.global_mha(summary_tokens, summary_tokens, summary_tokens, mask=global_causal_mask)
+        elif global_attention_type is None: # No global attention configured
+            if summary_tokens is None:
+                raise ValueError("Summary tokens are None, and no global attention is configured to pass them through.")
+            global_context_summaries = summary_tokens # Pass through
+        elif global_attention_type == "G1_full_mha" and not self.global_mha:
+             raise ValueError("G1_full_mha global attention configured but module not initialized.")
+        else: # Other types or misconfigurations
+            if summary_tokens is None:
+                 raise ValueError(f"Global attention type {global_attention_type} requires summary tokens, but they are None.")
+            # For other specified but not implemented global attention types, we might pass-through or error
+            # Current __init__ errors for other types, so this path implies pass-through for safety if reached.
+            print(f"Warning: Global attention type '{global_attention_type}' logic not fully implemented or not G1. Passing summary_tokens.")
+            global_context_summaries = summary_tokens
+        # global_context_summaries shape: (B, N, D)
+
+        # 5. Combination
+        combined_context_chunked = None
+        combination_type = self.combination_method_config.get('type')
+        if combination_type == "C1_broadcast_add":
+            if global_context_summaries is None:
+                 raise ValueError("Global context summaries are None, cannot apply C1_broadcast_add combination.")
+            if local_context is None: # Should not happen given the flow
+                 raise ValueError("Local context is None, cannot apply C1_broadcast_add combination.")
+            combined_context_chunked = self._combine_c1_broadcast_add(local_context, global_context_summaries)
+        elif combination_type is None:
+            raise ValueError("Combination type not specified in combination_method_config.")
+        else:
+            raise ValueError(f"Unsupported combination type: {combination_type}")
+        # combined_context_chunked shape: (B, N, C, D)
+
+        # 6. Reshape to final output dimensions
+        # Reshape from (B, N, C, D) to (B, N*C, D)
+        output_tensor = combined_context_chunked.contiguous().view(batch_size, -1, d_model)
+        
+        # Remove padding
+        if padding_needed > 0:
+            output_tensor = output_tensor[:, :original_seq_len, :]
+        
+        return output_tensor, None # Final output, None for attention_weights
+        # This mask is (1, 1, chunk_size, chunk_size) and will be broadcasted by MHA.
+        # `torch.tril` creates a lower triangular matrix (1s in lower triangle, 0s in upper).
+        # `ScaledDotProductAttention` in `vanilla_mha` uses `mask == 0` to mask positions.
+        # So, this mask correctly allows attention to previous and current positions within a chunk.
+        sz = self.chunk_size
+        causal_mask_for_local_attn = torch.tril(torch.ones(sz, sz, device=x.device)).unsqueeze(0).unsqueeze(0)
+        # Shape of causal_mask_for_local_attn: (1, 1, self.chunk_size, self.chunk_size)
+
+        # Apply local MHA
+        # local_context shape: (batch_size * num_chunks, self.chunk_size, d_model)
+        # We pass local_mha_input for Q, K, V as it's self-attention within chunks.
+        local_context, _ = self.local_mha(
+            query=local_mha_input, 
+            key=local_mha_input, 
+            value=local_mha_input, 
+            mask=causal_mask_for_local_attn
+        )
+        

--- a/my_attention_research_project/models/transformer.py
+++ b/my_attention_research_project/models/transformer.py
@@ -5,6 +5,7 @@ import math # For sqrt if used for scaling embeddings
 
 from .common_layers import PositionalEncoding, PositionwiseFeedForward, TokenEmbedding
 from .attention.vanilla_mha import MultiHeadAttention
+from .attention.ahc_attention import AHCAttention # Import AHCAttention
 
 
 class TransformerEncoderLayer(nn.Module):
@@ -77,7 +78,7 @@ class TransformerEncoder(nn.Module):
     Args:
         vocab_size (int): Size of the input vocabulary.
         d_model (int): The dimension of the model (embeddings, attention, etc.).
-        n_heads (int): Number of attention heads in MultiHeadAttention.
+        attention_config (dict): Configuration for the attention module.
         num_encoder_layers (int): Number of stacked TransformerEncoderLayer instances.
         ffn_dim_factor (int, optional): Factor to determine d_ff (d_ff = d_model * ffn_dim_factor).
                                        Defaults to 4.
@@ -93,19 +94,19 @@ class TransformerEncoder(nn.Module):
         embedding_scale_grad_by_freq (bool, optional): Passed to TokenEmbedding for nn.Embedding's
                                                        `scale_grad_by_freq` argument. Defaults to False.
     """
-    def __init__(self, 
-                 vocab_size: int, 
-                 d_model: int, 
-                 n_heads: int, 
-                 num_encoder_layers: int, 
+    def __init__(self,
+                 vocab_size: int,
+                 d_model: int,
+                 attention_config: dict, # Added attention_config
+                 num_encoder_layers: int,
                  ffn_dim_factor: int = 4,
-                 dropout_rate: float = 0.1, 
+                 dropout_rate: float = 0.1,
                  use_positional_embeddings: bool = True,
                  pos_encoding_max_len: int = 5000,
                  embedding_scale_factor: float = None,
                  embedding_scale_grad_by_freq: bool = False):
         super().__init__()
-        
+
         self.d_model = d_model
         self.use_positional_embeddings = use_positional_embeddings
 
@@ -130,19 +131,72 @@ class TransformerEncoder(nn.Module):
 
         # 4. Encoder Layers
         d_ff = d_model * ffn_dim_factor
-        attention_module = MultiHeadAttention(d_model, n_heads, dropout_rate=dropout_rate)
+
+        # Dynamically instantiate attention module
+        attention_type = attention_config.get("type", "VanillaMHA")
+        if attention_type == "VanillaMHA":
+            # Ensure n_heads is present in attention_config for VanillaMHA
+            if "n_heads" not in attention_config:
+                raise ValueError("n_heads is required in attention_config for VanillaMHA")
+            attention_module = MultiHeadAttention(
+                d_model=d_model,
+                n_heads=attention_config["n_heads"],
+                dropout_rate=attention_config.get("dropout_rate", dropout_rate) # Inherit or use specific
+            )
+        elif attention_type == "AHC":
+            # For AHC, d_model and dropout_rate are fundamental. Other AHC-specific params
+            # like n_heads (for local MHA), chunk_size, etc., should be in attention_config.
+            # Example: pass all of attention_config to AHCAttention, let it handle specifics.
+            ahc_params = attention_config.copy() # Make a copy to avoid modifying original
+            ahc_params.pop("type") # Remove type as it's not an AHCAttention constructor arg
+            
+            # Ensure d_model and dropout_rate are correctly passed.
+            # They can be overridden by values in attention_config if explicitly set there.
+            ahc_params["d_model"] = d_model 
+            ahc_params["dropout_rate"] = attention_config.get("dropout_rate", dropout_rate)
+
+            # Placeholder for AHCAttention instantiation
+            # self.attention_module = AHCAttention(**ahc_params)
+            # For now, as AHCAttention might not be fully implemented or its exact params defined:
+            # We can raise a NotImplementedError or print a message.
+            # Let's assume AHCAttention will take d_model, dropout_rate, and other specific configs
+            # For the purpose of this step, we'll prepare for its instantiation.
+            # The actual AHCAttention class would need to handle these params.
+            # For example, if AHCAttention takes d_model, n_heads (local), chunk_size etc.
+            # and we expect them in attention_config.
+            if "n_heads" not in ahc_params: # Assuming AHC also needs n_heads for its local attention
+                 raise ValueError("n_heads is required in attention_config for AHC")
+
+            # This is a conceptual instantiation. The actual AHCAttention class will define its args.
+            # For now, let's ensure it gets d_model and dropout_rate, plus other config.
+            attention_module = AHCAttention(
+                d_model=d_model,
+                # n_heads=ahc_params.pop("n_heads"), # AHCAttention would take n_heads directly
+                # chunk_size=ahc_params.pop("chunk_size"), # Example
+                # ... other AHC specific parameters from ahc_params
+                **ahc_params # Pass the rest of the AHC specific params
+            )
+            # For the subtask, the above instantiation is what we aim for.
+            # If AHCAttention is not yet implemented, this line would fail at runtime.
+            # For now, to make it runnable for testing VanillaMHA, we can use a placeholder:
+            # raise NotImplementedError(f"Attention type '{attention_type}' not fully implemented yet.")
+            # However, the goal is to set up the structure, so we'll assume AHCAttention can be imported.
+
+        else:
+            raise ValueError(f"Unsupported attention type: {attention_type}")
+
         feed_forward_module = PositionwiseFeedForward(d_model, d_ff, dropout_rate=dropout_rate)
-        
+
         # Note: The dropout_rate passed to TransformerEncoderLayer is for dropout on att_output and ffn_output
         # within that layer, before the residual connection.
         encoder_layer = TransformerEncoderLayer(
-            d_model, 
-            attention_module, 
-            feed_forward_module, 
-            dropout_rate=dropout_rate 
+            d_model,
+            attention_module,
+            feed_forward_module,
+            dropout_rate=dropout_rate
         )
         self.layers = nn.ModuleList([copy.deepcopy(encoder_layer) for _ in range(num_encoder_layers)])
-        
+
         # 5. Final Layer Normalization (applied after all encoder layers)
         self.norm = nn.LayerNorm(d_model, eps=1e-6)
 


### PR DESCRIPTION
This commit introduces the Advanced Hierarchical Chunking (AHC) attention mechanism as a new, configurable attention module.

Key changes include:

1.  **TransformerEncoder Modification:**
    *   `models/transformer.py` updated to allow dynamic instantiation of
        attention modules (VanillaMHA or AHC) based on configuration.

2.  **AHCAttention Class (`models/attention/ahc_attention.py`):**
    *   Handles chunking of input sequences with padding.
    *   Applies local Multi-Head Attention (MHA) within chunks (with causal masking).
    *   Implements two chunk summarization methods:
        *   AHC-S1: Pooling (mean/max) over local attention outputs.
        *   AHC-S2: Linear projection applied to pooled outputs.
    *   Implements global cross-chunk attention (AHC-G1):
        *   Full MHA applied to the sequence of summary tokens (with causal masking).
    *   Implements a combination method (C1_broadcast_add):
        *   Broadcasts globally-aware summary tokens and adds them to local
          attention outputs.
    *   The full pipeline (e.g., S1/S2 + G1 + C1) is selectable via configuration.

3.  **Configuration:**
    *   Added `configs/base_ahc_config.yaml` to define parameters for
        the AHC model, including chunk size, summarization, global attention,
        and combination strategies.

The AHC module is designed to be swappable with VanillaMHA in the TransformerEncoderLayer. This implementation covers the core AHC logic as per Research Direction 1. Further testing and integration into the training pipeline are the next steps.