### PR TITLE
feat: Implement Predictive Attention Scaffolding (PAS)

### DIFF
--- a/my_attention_research_project/configs/base_pas_config.yaml
+++ b/my_attention_research_project/configs/base_pas_config.yaml
@@ -1,0 +1,57 @@
+# Base Configuration for Perceiver Attention Sampling (PAS)
+
+model:
+  # TransformerEncoder overall parameters (can be adjusted)
+  d_model: 512
+  num_encoder_layers: 6
+  ffn_dim_factor: 4 # d_ff = d_model * ffn_dim_factor
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+
+  # Attention specific configuration
+  attention:
+    type: "PAS"       # Specifies the PAS attention module
+    # dropout_rate: 0.1 # Optional: Overall dropout for PAS module if it had other dropout layers.
+                        # PASAttention passes its dropout_rate to focused_attention_mha if not specified there.
+
+    scanner_config:
+      type: "PAS_P1_linear"
+      top_k_hotspots: 32
+      # Other scanner-specific parameters like projection dimensions could be added here
+      # if they were different from d_model or had specific needs.
+
+    focused_attention_config:
+      num_heads: 8        # Number of heads for the focused MultiHeadAttention
+      dropout_rate: 0.1   # Dropout rate for the focused MultiHeadAttention
+      # Other MHA-specific parameters (e.g., specific bias settings) could be added here.
+
+# Data configuration (example, can be same as base_mha_config.yaml or base_ahc_config.yaml)
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 512 # Max sequence length. For PAS, ensure this is reasonable for top_k_hotspots.
+  batch_size: 32
+  data_dir: "./data/processed/wikitext-103"
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json"
+
+# Training configuration (example, can be same as other base configs)
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 10 # Adjust as needed
+  random_seed: 42
+  gradient_clipping: 1.0
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 1000
+    min_lr: 0.00001
+
+# Benchmarking specific settings
+benchmarking:
+  batch_size_inference: 64
+  perplexity_eval_sequence_lengths: [512, 1024, 2048] # Consider relation to top_k_hotspots and sequence_length
+
+# Logging
+logging:
+  log_level: "INFO"
+  log_file: "training_pas.log"

--- a/my_attention_research_project/models/attention/pas_attention.py
+++ b/my_attention_research_project/models/attention/pas_attention.py
@@ -1,1 +1,195 @@
-# Placeholder for pas_attention.py
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from my_attention_research_project.models.attention.vanilla_mha import MultiHeadAttention
+
+class PASAttention(nn.Module):
+    """
+    Implements the Perceiver Attention Sampling (PAS) mechanism.
+    """
+    def __init__(self, 
+                 d_model: int, 
+                 scanner_config: dict, 
+                 focused_attention_config: dict, 
+                 dropout_rate: float = 0.0): # This dropout_rate is a general default
+        """
+        Initializes the PASAttention module.
+
+        Args:
+            d_model: The dimensionality of the input and output features.
+            scanner_config: Configuration dictionary for the scanner module.
+            focused_attention_config: Configuration dictionary for the focused attention module.
+            dropout_rate: Default dropout rate if not specified in focused_attention_config.
+        """
+        super().__init__()
+        self.d_model = d_model
+        self.scanner_config = scanner_config
+        self.focused_attention_config = focused_attention_config
+        # self.dropout_rate = dropout_rate # General dropout, not directly used here but stored if needed elsewhere
+
+        # Scanner initialization
+        if self.scanner_config.get("type") == "PAS_P1_linear":
+            self.scanner_q_proj = nn.Linear(self.d_model, self.d_model, bias=False)
+            self.scanner_k_proj = nn.Linear(self.d_model, self.d_model, bias=False)
+            self.top_k_hotspots = self.scanner_config.get("top_k_hotspots")
+            if self.top_k_hotspots is None:
+                raise ValueError("top_k_hotspots must be provided in scanner_config for PAS_P1_linear")
+            self.scanner = self._linear_scanner
+        else:
+            self.scanner = None 
+
+        # Focused Attention MHA initialization
+        mha_num_heads = self.focused_attention_config.get("num_heads")
+        if mha_num_heads is None:
+            raise ValueError("num_heads must be provided in focused_attention_config")
+        
+        # Use 0.0 as default for MHA dropout_rate if not specified in its config
+        mha_dropout_rate = self.focused_attention_config.get("dropout_rate", 0.0) 
+        
+        self.focused_attention_mha = MultiHeadAttention(
+            d_model=self.d_model, 
+            num_heads=mha_num_heads, 
+            dropout_rate=mha_dropout_rate
+        )
+        self.focused_attention = self._focused_sparse_attention
+
+
+    def _linear_scanner(self, 
+                        query_embed: torch.Tensor, 
+                        key_embed: torch.Tensor, 
+                        key_padding_mask: torch.Tensor = None) -> torch.Tensor:
+        """
+        Performs the linear scan to identify hotspots.
+        Args:
+            query_embed: Query tensor (batch_size, seq_len_q, d_model).
+            key_embed: Key tensor (batch_size, seq_len_k, d_model).
+            key_padding_mask: Padding mask for keys (batch_size, seq_len_k),
+                              where True or 1.0 indicates valid tokens, False or 0.0 for padding.
+        Returns:
+            hotspot_indices: Indices of the top_k hotspots (batch_size, seq_len_q, top_k_hotspots).
+        """
+        q_proj = self.scanner_q_proj(query_embed)
+        k_proj = self.scanner_k_proj(key_embed)
+
+        scores = torch.matmul(q_proj, k_proj.transpose(-2, -1))
+        scores = F.elu(scores) + 1
+
+        if key_padding_mask is not None:
+            mask = key_padding_mask.unsqueeze(1) # (batch_size, 1, seq_len_k)
+            if mask.dtype != torch.bool: 
+                mask = mask.bool()
+            scores = scores.masked_fill(mask == False, float('-inf'))
+
+        k_dim_size = scores.size(-1)
+        current_k = min(self.top_k_hotspots, k_dim_size)
+        
+        if k_dim_size == 0 : 
+            batch_size, seq_len_q, _ = query_embed.shape
+            return torch.empty((batch_size, seq_len_q, 0), dtype=torch.long, device=query_embed.device)
+
+        # If current_k is 0 (e.g. self.top_k_hotspots is 0), topk returns empty tensors.
+        # If all scores are -inf, topk still returns indices (they just correspond to -inf scores).
+        # The sparse attention mask will handle these 'invalid' selections.
+        _, hotspot_indices = torch.topk(scores, k=current_k, dim=-1)
+        
+        return hotspot_indices
+
+    def _focused_sparse_attention(self, 
+                                  query: torch.Tensor, 
+                                  key: torch.Tensor, 
+                                  value: torch.Tensor, 
+                                  hotspot_indices: torch.Tensor, 
+                                  original_key_padding_mask: torch.Tensor = None) -> torch.Tensor:
+        """
+        Performs focused sparse attention using the identified hotspots.
+        Args:
+            query: Query tensor (batch_size, seq_len_q, d_model).
+            key: Original full key sequence (batch_size, seq_len_k_orig, d_model).
+            value: Original full value sequence (batch_size, seq_len_k_orig, d_model).
+            hotspot_indices: Indices from Stage 1 (batch_size, seq_len_q, top_k_hotspots).
+            original_key_padding_mask: Padding mask for the original key sequence (batch_size, seq_len_k_orig).
+                                       True/1 for valid, False/0 for pad.
+        Returns:
+            context_vector: Output from the focused attention (batch_size, seq_len_q, d_model).
+        """
+        batch_size, seq_len_q, d_model_q = query.shape # d_model_q should be self.d_model
+        _, _, top_k = hotspot_indices.shape
+
+        if top_k == 0: # No hotspots selected (e.g. top_k_hotspots was 0 or seq_len_k was 0)
+            return torch.zeros_like(query)
+
+        expanded_hotspot_indices = hotspot_indices.unsqueeze(-1).expand(-1, -1, -1, self.d_model)
+
+        k_gathered = torch.gather(key.unsqueeze(1).expand(-1, seq_len_q, -1, -1), 
+                                  dim=2, 
+                                  index=expanded_hotspot_indices)
+        v_gathered = torch.gather(value.unsqueeze(1).expand(-1, seq_len_q, -1, -1), 
+                                  dim=2, 
+                                  index=expanded_hotspot_indices)
+
+        sparse_mask = torch.ones(batch_size, seq_len_q, top_k, device=query.device, dtype=torch.bool)
+
+        if original_key_padding_mask is not None:
+            # original_key_padding_mask: (B, S_k_orig), True for valid
+            # hotspot_indices: (B, S_q, top_k)
+            # gathered_padding_status: (B, S_q, top_k), True if original key at this hotspot index was valid
+            gathered_padding_status = torch.gather(
+                original_key_padding_mask.unsqueeze(1).expand(-1, seq_len_q, -1), 
+                dim=2, 
+                index=hotspot_indices
+            )
+            sparse_mask = sparse_mask & gathered_padding_status
+        
+        # sparse_mask: (batch_size, seq_len_q, top_k), True means attend, False means mask.
+        # MHA expects mask where False means "mask this position". This is consistent.
+        sparse_mask_for_mha = sparse_mask.unsqueeze(1).unsqueeze(2) # (B, 1, S_q, top_k)
+        
+        q_reshaped = query.contiguous().view(batch_size * seq_len_q, 1, self.d_model)
+        k_reshaped = k_gathered.contiguous().view(batch_size * seq_len_q, top_k, self.d_model)
+        v_reshaped = v_gathered.contiguous().view(batch_size * seq_len_q, top_k, self.d_model)
+        
+        # Mask for MHA: (B * S_q, 1, 1, top_k)
+        # Each of the (B * S_q) queries has length 1.
+        # The keys for each query have length top_k.
+        # The MHA mask should be (N, num_heads, L_q, L_k) or (N, L_q, L_k)
+        # Here N = B * S_q, L_q = 1, L_k = top_k
+        # So, mask_reshaped should be (B * S_q, 1, top_k) or (B*S_q, num_heads, 1, top_k)
+        # The prompt specifies mask_reshaped = sparse_mask_for_mha.view(batch_size * seq_len_q, 1, 1, top_k)
+        mask_reshaped = sparse_mask_for_mha.view(batch_size * seq_len_q, 1, 1, top_k)
+
+        context_reshaped, _ = self.focused_attention_mha(q_reshaped, k_reshaped, v_reshaped, mask=mask_reshaped)
+        
+        context_vector = context_reshaped.view(batch_size, seq_len_q, self.d_model)
+        return context_vector
+
+    def forward(self, 
+                query: torch.Tensor, 
+                key: torch.Tensor, 
+                value: torch.Tensor, 
+                input_padding_mask: torch.Tensor = None):
+        """
+        Performs the forward pass of the PASAttention module.
+
+        Args:
+            query: The query tensor (batch_size, seq_len_q, d_model).
+            key: The key tensor (batch_size, seq_len_k_orig, d_model).
+            value: The value tensor (batch_size, seq_len_k_orig, d_model).
+            input_padding_mask: An optional mask for input padding (batch_size, seq_len_k_orig).
+                                Assumed to be True/1 for valid, False/0 for padding.
+
+        Returns:
+            context_vector: The output tensor from the focused attention mechanism.
+            hotspot_indices: Indices of the top_k hotspots.
+        """
+        hotspot_indices = None
+        if self.scanner is not None:
+            hotspot_indices = self.scanner(query, key, input_padding_mask)
+        else:
+            raise NotImplementedError("Scanner is not configured, but PAS requires a scanner.")
+
+        if self.focused_attention is not None:
+            # Pass original_key_padding_mask (which is input_padding_mask) to focused attention
+            context_vector = self.focused_attention(query, key, value, hotspot_indices, input_padding_mask)
+            return context_vector, hotspot_indices
+        else:
+            raise NotImplementedError("Focused attention is not configured.")

--- a/my_attention_research_project/models/transformer.py
+++ b/my_attention_research_project/models/transformer.py
@@ -212,8 +212,31 @@ class TransformerEncoder(nn.Module):
                 d_model=d_model, 
                 **ahc_constructor_params # Pass all other AHC-specific params
             )
-        # Add elif blocks here for PASAttention, MOAEAttention when they are implemented
-        # e.g., elif attention_type == "PAS": from .attention.pas_attention import PASAttention ...
+        elif attention_type == "PAS":
+            try:
+                from .attention.pas_attention import PASAttention
+            except ImportError as e:
+                raise ImportError(
+                    f"Failed to import PASAttention for attention_type 'PAS'. "
+                    f"Ensure 'pas_attention.py' exists and is error-free. Original error: {e}"
+                )
+            
+            scanner_config = attention_config.get("scanner_config")
+            focused_attention_config = attention_config.get("focused_attention_config")
+            # Inherits from model's overall dropout_rate if not specified in PAS's part of attention_config
+            pas_dropout_rate = attention_config.get("dropout_rate", dropout_rate)
+
+            if scanner_config is None:
+                raise ValueError("scanner_config is required for PASAttention.")
+            if focused_attention_config is None:
+                raise ValueError("focused_attention_config is required for PASAttention.")
+
+            attention_module_instance = PASAttention(
+                d_model=d_model,
+                scanner_config=scanner_config,
+                focused_attention_config=focused_attention_config,
+                dropout_rate=pas_dropout_rate
+            )
         else:
             raise ValueError(f"Unsupported attention_type in config: '{attention_type}'")
 

--- a/my_attention_research_project/tests/models/attention/test_pas_attention.py
+++ b/my_attention_research_project/tests/models/attention/test_pas_attention.py
@@ -1,0 +1,183 @@
+import unittest
+import torch
+from my_attention_research_project.models.attention.pas_attention import PASAttention
+
+class TestPASAttention(unittest.TestCase):
+    def setUp(self):
+        self.batch_size = 2
+        self.seq_len_q = 10
+        self.seq_len_k = 12  # Key length can be different
+        self.d_model = 32
+        self.top_k_hotspots = 4
+        self.num_heads_focused = 4
+
+        self.scanner_config_linear = {
+            "type": "PAS_P1_linear",
+            "top_k_hotspots": self.top_k_hotspots
+        }
+        self.focused_attention_config_mha = {
+            "num_heads": self.num_heads_focused,
+            "dropout_rate": 0.0 # No dropout in tests
+        }
+        
+        self.pas_attention_default = PASAttention(
+            d_model=self.d_model,
+            scanner_config=self.scanner_config_linear,
+            focused_attention_config=self.focused_attention_config_mha,
+            dropout_rate=0.0 
+        )
+
+        self.query = torch.rand(self.batch_size, self.seq_len_q, self.d_model)
+        self.key = torch.rand(self.batch_size, self.seq_len_k, self.d_model)
+        self.value = torch.rand(self.batch_size, self.seq_len_k, self.d_model)
+
+    def test_pas_attention_initialization(self):
+        self.assertIsNotNone(self.pas_attention_default)
+        self.assertTrue(callable(self.pas_attention_default.scanner)) # Check if scanner method is assigned
+        self.assertIsNotNone(self.pas_attention_default.focused_attention_mha)
+        if self.pas_attention_default.scanner_config.get("type") == "PAS_P1_linear":
+            self.assertEqual(self.pas_attention_default.top_k_hotspots, self.top_k_hotspots)
+
+    # 2. Test PAS-P1 Linear Scanner
+    def test_linear_scanner_output_shape_and_values(self):
+        pas_attention = self.pas_attention_default
+        
+        # Call scanner directly (it's assigned to self.scanner in __init__)
+        # Ensure scanner is actually configured before calling
+        if not callable(pas_attention.scanner):
+            self.skipTest("Scanner not configured for this PASAttention instance.")
+
+        scanner_output_indices = pas_attention.scanner(self.query, self.key, None)
+        
+        self.assertEqual(scanner_output_indices.shape, 
+                         (self.batch_size, self.seq_len_q, self.top_k_hotspots))
+        
+        self.assertTrue(torch.all(scanner_output_indices >= 0))
+        self.assertTrue(torch.all(scanner_output_indices < self.seq_len_k))
+
+    def test_linear_scanner_padding_masking(self):
+        pas_attention = self.pas_attention_default
+        if not callable(pas_attention.scanner):
+            self.skipTest("Scanner not configured for this PASAttention instance.")
+
+        key_padding_mask = torch.ones(self.batch_size, self.seq_len_k, dtype=torch.bool)
+        num_padded_keys = 2
+        padded_indices_start = self.seq_len_k - num_padded_keys
+        key_padding_mask[:, padded_indices_start:] = False 
+        
+        hotspot_indices = pas_attention.scanner(self.query, self.key, key_padding_mask)
+        
+        # Handle case where top_k_hotspots might be 0
+        if self.top_k_hotspots == 0:
+            self.assertEqual(hotspot_indices.shape[-1], 0)
+            return # No indices to check
+
+        for b in range(self.batch_size):
+            for q_idx in range(self.seq_len_q):
+                for k_idx_pos in range(hotspot_indices.shape[2]): # Iterate up to actual number of hotspots returned
+                    selected_key_index = hotspot_indices[b, q_idx, k_idx_pos].item()
+                    is_padded = not key_padding_mask[b, selected_key_index].item()
+                    self.assertFalse(is_padded, 
+                                     f"Hotspot index {selected_key_index} at batch {b}, query_pos {q_idx} "
+                                     f"points to a padded key. Padded region starts at {padded_indices_start}.")
+    
+    # 3. Test Focused Sparse Attention
+    def test_focused_attention_output_shape(self):
+        pas_attention = self.pas_attention_default
+        if not callable(pas_attention.focused_attention):
+             self.skipTest("Focused attention not configured for this PASAttention instance.")
+
+        dummy_hotspot_indices = torch.randint(0, self.seq_len_k, 
+                                              (self.batch_size, self.seq_len_q, self.top_k_hotspots),
+                                              dtype=torch.long)
+        if self.top_k_hotspots == 0: # If top_k is 0, dummy_hotspot_indices will have last dim 0
+            dummy_hotspot_indices = torch.empty((self.batch_size, self.seq_len_q, 0), dtype=torch.long)
+
+
+        context = pas_attention.focused_attention(self.query, self.key, self.value, 
+                                                  dummy_hotspot_indices, None)
+        
+        self.assertEqual(context.shape, (self.batch_size, self.seq_len_q, self.d_model))
+
+    def test_focused_attention_masking_gathered_keys(self):
+        pas_attention = self.pas_attention_default
+        if not callable(pas_attention.focused_attention):
+            self.skipTest("Focused attention not configured for this PASAttention instance.")
+        if self.top_k_hotspots < 2: # This test assumes at least 2 hotspots can be selected
+            self.skipTest("top_k_hotspots is less than 2, skipping this specific masking test.")
+
+
+        hotspot_indices = torch.zeros(self.batch_size, self.seq_len_q, self.top_k_hotspots, dtype=torch.long)
+        
+        padded_key_original_index = self.seq_len_k - 1
+        hotspot_indices[0, 0, 0] = 0 
+        hotspot_indices[0, 0, 1] = padded_key_original_index 
+        if self.top_k_hotspots > 1: # ensure other hotspots are valid if they exist
+            hotspot_indices[:, :, 2:] = 1 
+
+
+        original_key_padding_mask = torch.ones(self.batch_size, self.seq_len_k, dtype=torch.bool)
+        original_key_padding_mask[:, padded_key_original_index] = False
+
+        distinct_value_marker = torch.ones(self.d_model) * 5.0 
+        value_for_test = torch.zeros_like(self.value)
+        value_for_test[:, padded_key_original_index, :] = distinct_value_marker
+        
+        non_padded_key_original_index = 0
+        non_padded_value_marker = torch.ones(self.d_model) * 1.0
+        value_for_test[:, non_padded_key_original_index, :] = non_padded_value_marker
+
+        context = pas_attention.focused_attention(self.query, self.key, value_for_test, 
+                                                  hotspot_indices, original_key_padding_mask)
+        
+        output_for_q00 = context[0, 0, :]
+
+        similarity_to_padded_value = torch.cosine_similarity(output_for_q00, distinct_value_marker, dim=0)
+        
+        # If output_for_q00 is all zeros (e.g. if all attended keys ended up being masked, or d_model is 1 and value is 0)
+        # then cosine similarity can be nan or 0. We should check this case.
+        is_output_zero = torch.allclose(output_for_q00, torch.zeros_like(output_for_q00), atol=1e-6)
+
+        self.assertTrue(is_output_zero or similarity_to_padded_value < 0.5, 
+                        f"Output context for query[0,0] seems to reflect contribution from the padded key. "
+                        f"Similarity to padded value: {similarity_to_padded_value.item()}. Output sum: {output_for_q00.sum().item()}")
+
+    # 4. Test PASAttention End-to-End
+    def test_pas_attention_e2e_run(self):
+        pas_attention = self.pas_attention_default
+        
+        # PASAttention.forward returns: context_vector, hotspot_indices
+        context, hotspot_indices_output = pas_attention(self.query, self.key, self.value, None)
+        
+        self.assertEqual(context.shape, (self.batch_size, self.seq_len_q, self.d_model))
+        self.assertIsNotNone(hotspot_indices_output)
+        self.assertEqual(hotspot_indices_output.shape, 
+                         (self.batch_size, self.seq_len_q, self.top_k_hotspots))
+
+    def test_pas_attention_e2e_with_padding(self):
+        pas_attention = self.pas_attention_default
+        
+        input_padding_mask = torch.ones(self.batch_size, self.seq_len_k, dtype=torch.bool)
+        num_padded_keys = 3
+        padded_indices_start = self.seq_len_k - num_padded_keys
+        input_padding_mask[:, padded_indices_start:] = False
+        
+        context, hotspot_indices_output = pas_attention(self.query, self.key, self.value, input_padding_mask)
+        
+        self.assertEqual(context.shape, (self.batch_size, self.seq_len_q, self.d_model))
+        self.assertIsNotNone(hotspot_indices_output)
+        self.assertEqual(hotspot_indices_output.shape, 
+                         (self.batch_size, self.seq_len_q, self.top_k_hotspots))
+        
+        if self.top_k_hotspots > 0 and hotspot_indices_output.shape[2] > 0 : # if any hotspots were actually returned
+            for b in range(self.batch_size):
+                for q_idx in range(self.seq_len_q):
+                    for k_idx_pos in range(hotspot_indices_output.shape[2]):
+                        selected_key_index = hotspot_indices_output[b, q_idx, k_idx_pos].item()
+                        is_padded = not input_padding_mask[b, selected_key_index].item()
+                        self.assertFalse(is_padded,
+                                         f"E2E: Hotspot index {selected_key_index} at batch {b}, query_pos {q_idx} "
+                                         f"points to a padded key. Padded region starts at {padded_indices_start}.")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This implements the Predictive Attention Scaffolding (PAS) attention mechanism, a two-stage process designed for efficient attention.

**Stage 1 (Rapid Context Scanner - PAS-P1 Linear):**
- Uses linear projections for Q and K.
- Computes scores via `elu(QK^T) + 1`.
- Selects `top_k_hotspots` key indices for each query token.
- Correctly handles padding masks to avoid selecting padded keys.

**Stage 2 (Focused Sparse Attention):**
- Gathers key and value vectors based on hotspot indices from Stage 1.
- Applies a standard Multi-Head Attention (MHA) to the query and its gathered (sparse) keys/values.
- Implements a new masking mechanism for this sparse MHA, ensuring that padding from the original key sequence is respected for the gathered keys.

**Integration:**
- `PASAttention` is integrated into the `TransformerEncoder` and can be selected via the model configuration file.
- A new configuration file `base_pas_config.yaml` is added to demonstrate its usage.

**Testing:**
- Comprehensive unit tests are added for `PASAttention`, covering:
    - PAS-P1 linear scanner logic and padding.
    - Focused sparse attention, including K/V gathering and sparse masking.
    - End-to-end functionality of the PAS module.