### PR TITLE
feat: Set up comprehensive benchmarking framework

### DIFF
--- a/my_attention_research_project/benchmarking/evaluate_perplexity.py
+++ b/my_attention_research_project/benchmarking/evaluate_perplexity.py
@@ -1,1 +1,7 @@
-# Placeholder for evaluate_perplexity.py
+# Placeholder for standalone perplexity evaluation on a test set.
+# Current benchmarking setup uses validation perplexity from the Trainer.
+# This script can be developed later if dedicated test set evaluation
+# with specific checkpoints is required.
+
+if __name__ == '__main__':
+    pass

--- a/my_attention_research_project/benchmarking/measure_speed_memory.py
+++ b/my_attention_research_project/benchmarking/measure_speed_memory.py
@@ -1,1 +1,141 @@
-# Placeholder for measure_speed_memory.py
+# Placeholder for standalone inference speed and memory measurement.
+# This script will load trained model checkpoints and run controlled
+# inference loops to gather stable performance metrics.
+# Key metrics: inference tokens/sec, peak inference GPU memory,
+# (Future) KV cache size.
+
+import argparse
+import torch
+import logging
+import time # Added for speed measurement
+
+# --- Project-specific imports (commented out to prevent errors if run standalone early) ---
+# from my_attention_research_project.utils.config_parser import load_config
+# from my_attention_research_project.models.transformer import TransformerEncoder
+# from my_attention_research_project.data.tokenizer import load_tokenizer # Assuming a function like this
+# from my_attention_research_project.data.wikitext103 import CausalLMTrainingDataset # Or a generic dataloader
+# --- End project-specific imports ---
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Measure inference speed and memory for a trained model.")
+    parser.add_argument("--config_path", type=str, required=True, help="Path to the model configuration YAML file used for training.")
+    parser.add_argument("--checkpoint_path", type=str, required=True, help="Path to the trained model checkpoint (.pt file).")
+    parser.add_argument("--batch_size", type=int, default=8, help="Batch size for inference.")
+    parser.add_argument("--sequence_length", type=int, default=None, help="Sequence length for dummy input. If None, uses from config.")
+    parser.add_argument("--num_batches", type=int, default=100, help="Number of batches to run for speed measurement.")
+    parser.add_argument("--warmup_batches", type=int, default=10, help="Number of warmup batches before measurement.")
+    parser.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu", help="Device for inference.")
+    return parser.parse_args()
+
+def main():
+    args = parse_args()
+    
+    # Setup basic logging
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+    logger = logging.getLogger(__name__)
+
+    logger.info(f"Starting inference speed/memory measurement for checkpoint: {args.checkpoint_path}")
+    logger.info(f"Using config: {args.config_path}")
+    logger.info(f"Device: {args.device}, Batch Size: {args.batch_size}, Sequence Length: {args.sequence_length or 'from config'}, Num Batches: {args.num_batches}, Warmup Batches: {args.warmup_batches}")
+
+    # TODO:
+    # 1. Load configuration from args.config_path
+    #    config = load_config(args.config_path)
+    #    if not config:
+    #        logger.error("Failed to load config.")
+    #        return
+
+    # 2. Determine sequence_length and batch_size
+    #    sequence_length = args.sequence_length if args.sequence_length is not None else config.get('data', {}).get('sequence_length', 512)
+    #    batch_size = args.batch_size 
+    #    logger.info(f"Effective Sequence Length: {sequence_length}, Batch Size: {batch_size}")
+
+    # 3. Initialize Tokenizer (needed for vocab_size if not in model config, or for real data if used)
+    #    tokenizer_path = config.get('data', {}).get('tokenizer_path', 'gpt2') # Example
+    #    tokenizer = load_tokenizer(tokenizer_path)
+    #    vocab_size = tokenizer.vocab_size
+
+    # 4. Initialize Model
+    #    model_config = config.get('model', {})
+    #    attention_config = model_config.get('attention', {})
+    #    # Ensure vocab_size is available for model init, e.g., from tokenizer or directly in config
+    #    model_vocab_size = model_config.get('vocab_size', vocab_size) 
+    #    model = TransformerEncoder(
+    #        vocab_size=model_vocab_size,
+    #        d_model=model_config.get('d_model'),
+    #        attention_config=attention_config,
+    #        # ... other params from config ...
+    #    )
+    #    logger.info("Model initialized.")
+
+    # 5. Load model checkpoint and set to eval mode
+    #    checkpoint = torch.load(args.checkpoint_path, map_location='cpu') # Load to CPU first
+    #    model.load_state_dict(checkpoint['model_state_dict'])
+    #    model.to(args.device)
+    #    model.eval()
+    #    logger.info(f"Model loaded from {args.checkpoint_path} and set to eval mode on {args.device}.")
+
+    # 6. Generate dummy input data (random token IDs)
+    #    dummy_input_ids = torch.randint(0, model_vocab_size, (batch_size, sequence_length), device=args.device, dtype=torch.long)
+    #    dummy_attention_mask = torch.ones_like(dummy_input_ids) # All tokens attended
+    #    logger.info(f"Generated dummy input data of shape: {dummy_input_ids.shape}")
+
+    # 7. Warm-up phase
+    #    logger.info(f"Running {args.warmup_batches} warm-up batches...")
+    #    for _ in range(args.warmup_batches):
+    #        with torch.no_grad():
+    #            _ = model(input_ids=dummy_input_ids, attention_mask=dummy_attention_mask)
+    #    if args.device == 'cuda':
+    #        torch.cuda.synchronize() # Wait for GPU operations to complete
+    #    logger.info("Warm-up complete.")
+
+    # 8. Main measurement loop
+    #    total_tokens_processed = 0
+    #    total_time_elapsed = 0
+    #    logger.info(f"Running {args.num_batches} measurement batches...")
+    #    if args.device == 'cuda':
+    #        torch.cuda.reset_peak_memory_stats(args.device) # Reset before measurement
+    #        start_event = torch.cuda.Event(enable_timing=True)
+    #        end_event = torch.cuda.Event(enable_timing=True)
+
+    #    for i in range(args.num_batches):
+    #        if args.device == 'cuda':
+    #            start_event.record()
+    #        else:
+    #            batch_start_time = time.perf_counter()
+
+    #        with torch.no_grad():
+    #            _ = model(input_ids=dummy_input_ids, attention_mask=dummy_attention_mask)
+
+    #        if args.device == 'cuda':
+    #            end_event.record()
+    #            torch.cuda.synchronize() # Wait for GPU operations
+    #            total_time_elapsed += start_event.elapsed_time(end_event) / 1000.0 # Convert ms to s
+    #        else:
+    #            batch_end_time = time.perf_counter()
+    #            total_time_elapsed += (batch_end_time - batch_start_time)
+            
+    #        total_tokens_processed += dummy_input_ids.numel()
+    #        if (i + 1) % (args.num_batches // 10 if args.num_batches >=10 else 1) == 0:
+    #             logger.info(f"  Completed batch {i+1}/{args.num_batches}")
+
+
+    # 9. Calculate and log tokens/second
+    #    if total_time_elapsed > 0:
+    #        tokens_per_second = total_tokens_processed / total_time_elapsed
+    #        logger.info(f"Throughput: {tokens_per_second:.2f} tokens/second")
+    #    else:
+    #        logger.info("Total time elapsed is zero, cannot calculate throughput.")
+
+    # 10. Measure and log peak GPU memory
+    #    if args.device == 'cuda':
+    #        peak_memory_mb = torch.cuda.max_memory_allocated(args.device) / (1024 * 1024)
+    #        logger.info(f"Peak GPU Memory Allocated during measurement: {peak_memory_mb:.2f} MB")
+    #    else:
+    #        logger.info("Running on CPU, GPU memory measurement not applicable.")
+
+    logger.warning("Standalone speed/memory measurement script is not fully implemented yet. TODOs need to be completed.")
+    pass
+
+if __name__ == "__main__":
+    main()

--- a/my_attention_research_project/configs/base_moae_config.yaml
+++ b/my_attention_research_project/configs/base_moae_config.yaml
@@ -1,0 +1,64 @@
+# Base Configuration for Mixture of Attention Experts (MOAE)
+
+model:
+  # TransformerEncoder overall parameters (can be adjusted)
+  d_model: 512
+  num_encoder_layers: 6
+  ffn_dim_factor: 4 # d_ff = d_model * ffn_dim_factor
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+
+  # Attention specific configuration
+  attention:
+    type: "MOAE"
+    dropout_rate: 0.1 # Overall dropout for MOAEAttention module (if used, or as default)
+
+    expert_configs:
+      - type: "local_window_mha"
+        n_heads: 4
+        window_size: 32
+        dropout_rate: 0.1 # Expert-specific dropout
+      - type: "dilated_mha"
+        n_heads: 4
+        dilation_rate: 2 # Attend to keys at positions 0, 2, 4,...
+        dropout_rate: 0.1 # Expert-specific dropout
+      # Example of a potential third expert (full attention) - not implemented in MOAEAttention __init__ yet
+      # - type: "vanilla_mha" 
+      #   n_heads: 2 
+      #   dropout_rate: 0.1
+
+    gating_config:
+      type: "soft_gate_mlp"
+      hidden_dim: 64   # Hidden dimension for the gating MLP
+      dropout_rate: 0.1 # Dropout for the gating network
+
+# Data configuration (example, can be same as base_pas_config.yaml)
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 512 
+  batch_size: 32
+  data_dir: "./data/processed/wikitext-103"
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json"
+
+# Training configuration (example, can be same as other base configs)
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 10 # Adjust as needed
+  random_seed: 42
+  gradient_clipping: 1.0
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 1000
+    min_lr: 0.00001
+
+# Benchmarking specific settings
+benchmarking:
+  batch_size_inference: 64
+  perplexity_eval_sequence_lengths: [512, 1024, 2048] 
+
+# Logging
+logging:
+  log_level: "INFO"
+  log_file: "training_moae.log"

--- a/my_attention_research_project/configs/base_pas_config.yaml
+++ b/my_attention_research_project/configs/base_pas_config.yaml
@@ -1,0 +1,57 @@
+# Base Configuration for Perceiver Attention Sampling (PAS)
+
+model:
+  # TransformerEncoder overall parameters (can be adjusted)
+  d_model: 512
+  num_encoder_layers: 6
+  ffn_dim_factor: 4 # d_ff = d_model * ffn_dim_factor
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+
+  # Attention specific configuration
+  attention:
+    type: "PAS"       # Specifies the PAS attention module
+    # dropout_rate: 0.1 # Optional: Overall dropout for PAS module if it had other dropout layers.
+                        # PASAttention passes its dropout_rate to focused_attention_mha if not specified there.
+
+    scanner_config:
+      type: "PAS_P1_linear"
+      top_k_hotspots: 32
+      # Other scanner-specific parameters like projection dimensions could be added here
+      # if they were different from d_model or had specific needs.
+
+    focused_attention_config:
+      num_heads: 8        # Number of heads for the focused MultiHeadAttention
+      dropout_rate: 0.1   # Dropout rate for the focused MultiHeadAttention
+      # Other MHA-specific parameters (e.g., specific bias settings) could be added here.
+
+# Data configuration (example, can be same as base_mha_config.yaml or base_ahc_config.yaml)
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 512 # Max sequence length. For PAS, ensure this is reasonable for top_k_hotspots.
+  batch_size: 32
+  data_dir: "./data/processed/wikitext-103"
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json"
+
+# Training configuration (example, can be same as other base configs)
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 10 # Adjust as needed
+  random_seed: 42
+  gradient_clipping: 1.0
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 1000
+    min_lr: 0.00001
+
+# Benchmarking specific settings
+benchmarking:
+  batch_size_inference: 64
+  perplexity_eval_sequence_lengths: [512, 1024, 2048] # Consider relation to top_k_hotspots and sequence_length
+
+# Logging
+logging:
+  log_level: "INFO"
+  log_file: "training_pas.log"

--- a/my_attention_research_project/configs/benchmarking/bench_ahc_seq1024.yaml
+++ b/my_attention_research_project/configs/benchmarking/bench_ahc_seq1024.yaml
@@ -1,0 +1,54 @@
+# Base parameters for benchmarking configurations
+# experiment_name will be set by the runner, usually based on filename
+
+model:
+  d_model: 256
+  num_encoder_layers: 4
+  ffn_dim_factor: 4
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+  # vocab_size will be set by the experiment_runner.py based on the tokenizer
+
+  # Attention specific configuration will be added below by each file
+  attention:
+    type: "AHC"
+    n_heads: 4 # For local MHA
+    chunk_size: 64
+    dropout_rate: 0.1 # Overall AHC dropout, can be overridden by sub-modules if they allow
+    summarization_method_config:
+      type: "S1_pool"
+      pool_type: "mean"
+    global_attention_method_config:
+      type: "G1_full_mha"
+      num_heads: 4 # For global MHA on summaries
+      # dropout_rate: 0.1 # Optional: specific dropout for global MHA
+    combination_method_config:
+      type: "C1_broadcast_add"
+
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 1024
+  batch_size: 16 
+  data_dir: "./data/processed/wikitext-103" # Path to processed data
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json" # Path to tokenizer
+  # tokenizer_max_length is usually in config['data'] and used by preprocessing.
+  # Should be >= sequence_length. If not set, a default is used in wikitext103.py.
+  tokenizer_max_length: 1024 # Set explicitly for clarity during benchmark runs
+
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 3 # Short duration for benchmarking purposes
+  gradient_clipping: 1.0
+  random_seed: 42
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 500 # Example, adjust based on total steps if used for real pre-training
+    min_lr: 0.000005
+  # checkpoint_dir will be set by experiment_runner or a main script
+  # results_dir will be set by experiment_runner or a main script
+
+logging:
+  log_level: "INFO"
+  log_file: "bench_ahc_seq1024.log"

--- a/my_attention_research_project/configs/benchmarking/bench_ahc_seq2048.yaml
+++ b/my_attention_research_project/configs/benchmarking/bench_ahc_seq2048.yaml
@@ -1,0 +1,54 @@
+# Base parameters for benchmarking configurations
+# experiment_name will be set by the runner, usually based on filename
+
+model:
+  d_model: 256
+  num_encoder_layers: 4
+  ffn_dim_factor: 4
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+  # vocab_size will be set by the experiment_runner.py based on the tokenizer
+
+  # Attention specific configuration will be added below by each file
+  attention:
+    type: "AHC"
+    n_heads: 4 # For local MHA
+    chunk_size: 64
+    dropout_rate: 0.1 # Overall AHC dropout, can be overridden by sub-modules if they allow
+    summarization_method_config:
+      type: "S1_pool"
+      pool_type: "mean"
+    global_attention_method_config:
+      type: "G1_full_mha"
+      num_heads: 4 # For global MHA on summaries
+      # dropout_rate: 0.1 # Optional: specific dropout for global MHA
+    combination_method_config:
+      type: "C1_broadcast_add"
+
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 2048
+  batch_size: 8 
+  data_dir: "./data/processed/wikitext-103" # Path to processed data
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json" # Path to tokenizer
+  # tokenizer_max_length is usually in config['data'] and used by preprocessing.
+  # Should be >= sequence_length. If not set, a default is used in wikitext103.py.
+  tokenizer_max_length: 2048 # Set explicitly for clarity during benchmark runs
+
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 3 # Short duration for benchmarking purposes
+  gradient_clipping: 1.0
+  random_seed: 42
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 500 # Example, adjust based on total steps if used for real pre-training
+    min_lr: 0.000005
+  # checkpoint_dir will be set by experiment_runner or a main script
+  # results_dir will be set by experiment_runner or a main script
+
+logging:
+  log_level: "INFO"
+  log_file: "bench_ahc_seq2048.log"

--- a/my_attention_research_project/configs/benchmarking/bench_ahc_seq4096.yaml
+++ b/my_attention_research_project/configs/benchmarking/bench_ahc_seq4096.yaml
@@ -1,0 +1,54 @@
+# Base parameters for benchmarking configurations
+# experiment_name will be set by the runner, usually based on filename
+
+model:
+  d_model: 256
+  num_encoder_layers: 4
+  ffn_dim_factor: 4
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+  # vocab_size will be set by the experiment_runner.py based on the tokenizer
+
+  # Attention specific configuration will be added below by each file
+  attention:
+    type: "AHC"
+    n_heads: 4 # For local MHA
+    chunk_size: 64 # AHC chunk_size is a key parameter, kept same as base for this benchmark series
+    dropout_rate: 0.1 # Overall AHC dropout, can be overridden by sub-modules if they allow
+    summarization_method_config:
+      type: "S1_pool"
+      pool_type: "mean"
+    global_attention_method_config:
+      type: "G1_full_mha"
+      num_heads: 4 # For global MHA on summaries
+      # dropout_rate: 0.1 # Optional: specific dropout for global MHA
+    combination_method_config:
+      type: "C1_broadcast_add"
+
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 4096
+  batch_size: 4 
+  data_dir: "./data/processed/wikitext-103" # Path to processed data
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json" # Path to tokenizer
+  # tokenizer_max_length is usually in config['data'] and used by preprocessing.
+  # Should be >= sequence_length. If not set, a default is used in wikitext103.py.
+  tokenizer_max_length: 4096 # Set explicitly for clarity during benchmark runs
+
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 3 # Short duration for benchmarking purposes
+  gradient_clipping: 1.0
+  random_seed: 42
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 500 # Example, adjust based on total steps if used for real pre-training
+    min_lr: 0.000005
+  # checkpoint_dir will be set by experiment_runner or a main script
+  # results_dir will be set by experiment_runner or a main script
+
+logging:
+  log_level: "INFO"
+  log_file: "bench_ahc_seq4096.log"

--- a/my_attention_research_project/configs/benchmarking/bench_ahc_seq512.yaml
+++ b/my_attention_research_project/configs/benchmarking/bench_ahc_seq512.yaml
@@ -1,0 +1,54 @@
+# Base parameters for benchmarking configurations
+# experiment_name will be set by the runner, usually based on filename
+
+model:
+  d_model: 256
+  num_encoder_layers: 4
+  ffn_dim_factor: 4
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+  # vocab_size will be set by the experiment_runner.py based on the tokenizer
+
+  # Attention specific configuration will be added below by each file
+  attention:
+    type: "AHC"
+    n_heads: 4 # For local MHA
+    chunk_size: 64
+    dropout_rate: 0.1 # Overall AHC dropout, can be overridden by sub-modules if they allow
+    summarization_method_config:
+      type: "S1_pool"
+      pool_type: "mean"
+    global_attention_method_config:
+      type: "G1_full_mha"
+      num_heads: 4 # For global MHA on summaries
+      # dropout_rate: 0.1 # Optional: specific dropout for global MHA
+    combination_method_config:
+      type: "C1_broadcast_add"
+
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 512
+  batch_size: 16 # Smaller batch size for potentially larger models or limited GPU memory during benchmark
+  data_dir: "./data/processed/wikitext-103" # Path to processed data
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json" # Path to tokenizer
+  # tokenizer_max_length is usually in config['data'] and used by preprocessing.
+  # Should be >= sequence_length. If not set, a default is used in wikitext103.py.
+  tokenizer_max_length: 512 # Set explicitly for clarity during benchmark runs
+
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 3 # Short duration for benchmarking purposes
+  gradient_clipping: 1.0
+  random_seed: 42
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 500 # Example, adjust based on total steps if used for real pre-training
+    min_lr: 0.000005
+  # checkpoint_dir will be set by experiment_runner or a main script
+  # results_dir will be set by experiment_runner or a main script
+
+logging:
+  log_level: "INFO"
+  log_file: "bench_ahc_seq512.log"

--- a/my_attention_research_project/configs/benchmarking/bench_moae_seq1024.yaml
+++ b/my_attention_research_project/configs/benchmarking/bench_moae_seq1024.yaml
@@ -1,0 +1,58 @@
+# Base parameters for benchmarking configurations
+# experiment_name will be set by the runner, usually based on filename
+
+model:
+  d_model: 256
+  num_encoder_layers: 4
+  ffn_dim_factor: 4
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+  # vocab_size will be set by the experiment_runner.py based on the tokenizer
+
+  # Attention specific configuration will be added below by each file
+  attention:
+    type: "MOAE"
+    dropout_rate: 0.1 # Overall MOAE module dropout
+
+    expert_configs:
+      - type: "local_window_mha"
+        n_heads: 2 # d_model 256 / 2 heads = head_dim 128
+        window_size: 64
+        dropout_rate: 0.1 # Expert-specific dropout
+      - type: "dilated_mha"
+        n_heads: 2 # d_model 256 / 2 heads = head_dim 128
+        dilation_rate: 4 # Attend to keys at 0, 4, 8 ...
+        dropout_rate: 0.1 # Expert-specific dropout
+    
+    gating_config:
+      type: "soft_gate_mlp"
+      hidden_dim: 64   # Hidden dimension for the gating MLP
+      dropout_rate: 0.1 # Dropout for the gating network
+
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 1024
+  batch_size: 16 
+  data_dir: "./data/processed/wikitext-103" # Path to processed data
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json" # Path to tokenizer
+  # tokenizer_max_length is usually in config['data'] and used by preprocessing.
+  # Should be >= sequence_length. If not set, a default is used in wikitext103.py.
+  tokenizer_max_length: 1024 # Set explicitly for clarity during benchmark runs
+
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 3 # Short duration for benchmarking purposes
+  gradient_clipping: 1.0
+  random_seed: 42
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 500 # Example, adjust based on total steps if used for real pre-training
+    min_lr: 0.000005
+  # checkpoint_dir will be set by experiment_runner or a main script
+  # results_dir will be set by experiment_runner or a main script
+
+logging:
+  log_level: "INFO"
+  log_file: "bench_moae_seq1024.log"

--- a/my_attention_research_project/configs/benchmarking/bench_moae_seq2048.yaml
+++ b/my_attention_research_project/configs/benchmarking/bench_moae_seq2048.yaml
@@ -1,0 +1,58 @@
+# Base parameters for benchmarking configurations
+# experiment_name will be set by the runner, usually based on filename
+
+model:
+  d_model: 256
+  num_encoder_layers: 4
+  ffn_dim_factor: 4
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+  # vocab_size will be set by the experiment_runner.py based on the tokenizer
+
+  # Attention specific configuration will be added below by each file
+  attention:
+    type: "MOAE"
+    dropout_rate: 0.1 # Overall MOAE module dropout
+
+    expert_configs:
+      - type: "local_window_mha"
+        n_heads: 2 # d_model 256 / 2 heads = head_dim 128
+        window_size: 64
+        dropout_rate: 0.1 # Expert-specific dropout
+      - type: "dilated_mha"
+        n_heads: 2 # d_model 256 / 2 heads = head_dim 128
+        dilation_rate: 4 # Attend to keys at 0, 4, 8 ...
+        dropout_rate: 0.1 # Expert-specific dropout
+    
+    gating_config:
+      type: "soft_gate_mlp"
+      hidden_dim: 64   # Hidden dimension for the gating MLP
+      dropout_rate: 0.1 # Dropout for the gating network
+
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 2048
+  batch_size: 8 
+  data_dir: "./data/processed/wikitext-103" # Path to processed data
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json" # Path to tokenizer
+  # tokenizer_max_length is usually in config['data'] and used by preprocessing.
+  # Should be >= sequence_length. If not set, a default is used in wikitext103.py.
+  tokenizer_max_length: 2048 # Set explicitly for clarity during benchmark runs
+
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 3 # Short duration for benchmarking purposes
+  gradient_clipping: 1.0
+  random_seed: 42
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 500 # Example, adjust based on total steps if used for real pre-training
+    min_lr: 0.000005
+  # checkpoint_dir will be set by experiment_runner or a main script
+  # results_dir will be set by experiment_runner or a main script
+
+logging:
+  log_level: "INFO"
+  log_file: "bench_moae_seq2048.log"

--- a/my_attention_research_project/configs/benchmarking/bench_moae_seq4096.yaml
+++ b/my_attention_research_project/configs/benchmarking/bench_moae_seq4096.yaml
@@ -1,0 +1,58 @@
+# Base parameters for benchmarking configurations
+# experiment_name will be set by the runner, usually based on filename
+
+model:
+  d_model: 256
+  num_encoder_layers: 4
+  ffn_dim_factor: 4
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+  # vocab_size will be set by the experiment_runner.py based on the tokenizer
+
+  # Attention specific configuration will be added below by each file
+  attention:
+    type: "MOAE"
+    dropout_rate: 0.1 # Overall MOAE module dropout
+
+    expert_configs:
+      - type: "local_window_mha"
+        n_heads: 2 # d_model 256 / 2 heads = head_dim 128
+        window_size: 64
+        dropout_rate: 0.1 # Expert-specific dropout
+      - type: "dilated_mha"
+        n_heads: 2 # d_model 256 / 2 heads = head_dim 128
+        dilation_rate: 4 # Attend to keys at 0, 4, 8 ...
+        dropout_rate: 0.1 # Expert-specific dropout
+    
+    gating_config:
+      type: "soft_gate_mlp"
+      hidden_dim: 64   # Hidden dimension for the gating MLP
+      dropout_rate: 0.1 # Dropout for the gating network
+
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 4096
+  batch_size: 4 
+  data_dir: "./data/processed/wikitext-103" # Path to processed data
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json" # Path to tokenizer
+  # tokenizer_max_length is usually in config['data'] and used by preprocessing.
+  # Should be >= sequence_length. If not set, a default is used in wikitext103.py.
+  tokenizer_max_length: 4096 # Set explicitly for clarity during benchmark runs
+
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 3 # Short duration for benchmarking purposes
+  gradient_clipping: 1.0
+  random_seed: 42
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 500 # Example, adjust based on total steps if used for real pre-training
+    min_lr: 0.000005
+  # checkpoint_dir will be set by experiment_runner or a main script
+  # results_dir will be set by experiment_runner or a main script
+
+logging:
+  log_level: "INFO"
+  log_file: "bench_moae_seq4096.log"

--- a/my_attention_research_project/configs/benchmarking/bench_moae_seq512.yaml
+++ b/my_attention_research_project/configs/benchmarking/bench_moae_seq512.yaml
@@ -1,0 +1,58 @@
+# Base parameters for benchmarking configurations
+# experiment_name will be set by the runner, usually based on filename
+
+model:
+  d_model: 256
+  num_encoder_layers: 4
+  ffn_dim_factor: 4
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+  # vocab_size will be set by the experiment_runner.py based on the tokenizer
+
+  # Attention specific configuration will be added below by each file
+  attention:
+    type: "MOAE"
+    dropout_rate: 0.1 # Overall MOAE module dropout
+
+    expert_configs:
+      - type: "local_window_mha"
+        n_heads: 2 # d_model 256 / 2 heads = head_dim 128
+        window_size: 64
+        dropout_rate: 0.1 # Expert-specific dropout
+      - type: "dilated_mha"
+        n_heads: 2 # d_model 256 / 2 heads = head_dim 128
+        dilation_rate: 4 # Attend to keys at 0, 4, 8 ...
+        dropout_rate: 0.1 # Expert-specific dropout
+    
+    gating_config:
+      type: "soft_gate_mlp"
+      hidden_dim: 64   # Hidden dimension for the gating MLP
+      dropout_rate: 0.1 # Dropout for the gating network
+
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 512
+  batch_size: 16 # Smaller batch size for potentially larger models or limited GPU memory during benchmark
+  data_dir: "./data/processed/wikitext-103" # Path to processed data
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json" # Path to tokenizer
+  # tokenizer_max_length is usually in config['data'] and used by preprocessing.
+  # Should be >= sequence_length. If not set, a default is used in wikitext103.py.
+  tokenizer_max_length: 512 # Set explicitly for clarity during benchmark runs
+
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 3 # Short duration for benchmarking purposes
+  gradient_clipping: 1.0
+  random_seed: 42
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 500 # Example, adjust based on total steps if used for real pre-training
+    min_lr: 0.000005
+  # checkpoint_dir will be set by experiment_runner or a main script
+  # results_dir will be set by experiment_runner or a main script
+
+logging:
+  log_level: "INFO"
+  log_file: "bench_moae_seq512.log"

--- a/my_attention_research_project/configs/benchmarking/bench_pas_seq1024.yaml
+++ b/my_attention_research_project/configs/benchmarking/bench_pas_seq1024.yaml
@@ -1,0 +1,50 @@
+# Base parameters for benchmarking configurations
+# experiment_name will be set by the runner, usually based on filename
+
+model:
+  d_model: 256
+  num_encoder_layers: 4
+  ffn_dim_factor: 4
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+  # vocab_size will be set by the experiment_runner.py based on the tokenizer
+
+  # Attention specific configuration will be added below by each file
+  attention:
+    type: "PAS"
+    dropout_rate: 0.1 # Overall PAS module dropout (passed to focused_attention_config if not specified there)
+    scanner_config:
+      type: "PAS_P1_linear"
+      top_k_hotspots: 64 
+      # proj_dim: d_model (default)
+    focused_attention_config:
+      num_heads: 4 # d_model 256 / 4 heads = head_dim 64
+      dropout_rate: 0.1 # Specific dropout for the focused MHA
+
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 1024
+  batch_size: 16 
+  data_dir: "./data/processed/wikitext-103" # Path to processed data
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json" # Path to tokenizer
+  # tokenizer_max_length is usually in config['data'] and used by preprocessing.
+  # Should be >= sequence_length. If not set, a default is used in wikitext103.py.
+  tokenizer_max_length: 1024 # Set explicitly for clarity during benchmark runs
+
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 3 # Short duration for benchmarking purposes
+  gradient_clipping: 1.0
+  random_seed: 42
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 500 # Example, adjust based on total steps if used for real pre-training
+    min_lr: 0.000005
+  # checkpoint_dir will be set by experiment_runner or a main script
+  # results_dir will be set by experiment_runner or a main script
+
+logging:
+  log_level: "INFO"
+  log_file: "bench_pas_seq1024.log"

--- a/my_attention_research_project/configs/benchmarking/bench_pas_seq2048.yaml
+++ b/my_attention_research_project/configs/benchmarking/bench_pas_seq2048.yaml
@@ -1,0 +1,50 @@
+# Base parameters for benchmarking configurations
+# experiment_name will be set by the runner, usually based on filename
+
+model:
+  d_model: 256
+  num_encoder_layers: 4
+  ffn_dim_factor: 4
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+  # vocab_size will be set by the experiment_runner.py based on the tokenizer
+
+  # Attention specific configuration will be added below by each file
+  attention:
+    type: "PAS"
+    dropout_rate: 0.1 # Overall PAS module dropout (passed to focused_attention_config if not specified there)
+    scanner_config:
+      type: "PAS_P1_linear"
+      top_k_hotspots: 64 
+      # proj_dim: d_model (default)
+    focused_attention_config:
+      num_heads: 4 # d_model 256 / 4 heads = head_dim 64
+      dropout_rate: 0.1 # Specific dropout for the focused MHA
+
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 2048
+  batch_size: 8 
+  data_dir: "./data/processed/wikitext-103" # Path to processed data
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json" # Path to tokenizer
+  # tokenizer_max_length is usually in config['data'] and used by preprocessing.
+  # Should be >= sequence_length. If not set, a default is used in wikitext103.py.
+  tokenizer_max_length: 2048 # Set explicitly for clarity during benchmark runs
+
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 3 # Short duration for benchmarking purposes
+  gradient_clipping: 1.0
+  random_seed: 42
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 500 # Example, adjust based on total steps if used for real pre-training
+    min_lr: 0.000005
+  # checkpoint_dir will be set by experiment_runner or a main script
+  # results_dir will be set by experiment_runner or a main script
+
+logging:
+  log_level: "INFO"
+  log_file: "bench_pas_seq2048.log"

--- a/my_attention_research_project/configs/benchmarking/bench_pas_seq4096.yaml
+++ b/my_attention_research_project/configs/benchmarking/bench_pas_seq4096.yaml
@@ -1,0 +1,50 @@
+# Base parameters for benchmarking configurations
+# experiment_name will be set by the runner, usually based on filename
+
+model:
+  d_model: 256
+  num_encoder_layers: 4
+  ffn_dim_factor: 4
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+  # vocab_size will be set by the experiment_runner.py based on the tokenizer
+
+  # Attention specific configuration will be added below by each file
+  attention:
+    type: "PAS"
+    dropout_rate: 0.1 # Overall PAS module dropout (passed to focused_attention_config if not specified there)
+    scanner_config:
+      type: "PAS_P1_linear"
+      top_k_hotspots: 64 
+      # proj_dim: d_model (default)
+    focused_attention_config:
+      num_heads: 4 # d_model 256 / 4 heads = head_dim 64
+      dropout_rate: 0.1 # Specific dropout for the focused MHA
+
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 4096
+  batch_size: 4 
+  data_dir: "./data/processed/wikitext-103" # Path to processed data
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json" # Path to tokenizer
+  # tokenizer_max_length is usually in config['data'] and used by preprocessing.
+  # Should be >= sequence_length. If not set, a default is used in wikitext103.py.
+  tokenizer_max_length: 4096 # Set explicitly for clarity during benchmark runs
+
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 3 # Short duration for benchmarking purposes
+  gradient_clipping: 1.0
+  random_seed: 42
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 500 # Example, adjust based on total steps if used for real pre-training
+    min_lr: 0.000005
+  # checkpoint_dir will be set by experiment_runner or a main script
+  # results_dir will be set by experiment_runner or a main script
+
+logging:
+  log_level: "INFO"
+  log_file: "bench_pas_seq4096.log"

--- a/my_attention_research_project/configs/benchmarking/bench_pas_seq512.yaml
+++ b/my_attention_research_project/configs/benchmarking/bench_pas_seq512.yaml
@@ -1,0 +1,50 @@
+# Base parameters for benchmarking configurations
+# experiment_name will be set by the runner, usually based on filename
+
+model:
+  d_model: 256
+  num_encoder_layers: 4
+  ffn_dim_factor: 4
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+  # vocab_size will be set by the experiment_runner.py based on the tokenizer
+
+  # Attention specific configuration will be added below by each file
+  attention:
+    type: "PAS"
+    dropout_rate: 0.1 # Overall PAS module dropout (passed to focused_attention_config if not specified there)
+    scanner_config:
+      type: "PAS_P1_linear"
+      top_k_hotspots: 64 
+      # proj_dim: d_model (default)
+    focused_attention_config:
+      num_heads: 4 # d_model 256 / 4 heads = head_dim 64
+      dropout_rate: 0.1 # Specific dropout for the focused MHA
+
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 512
+  batch_size: 16 # Smaller batch size for potentially larger models or limited GPU memory during benchmark
+  data_dir: "./data/processed/wikitext-103" # Path to processed data
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json" # Path to tokenizer
+  # tokenizer_max_length is usually in config['data'] and used by preprocessing.
+  # Should be >= sequence_length. If not set, a default is used in wikitext103.py.
+  tokenizer_max_length: 512 # Set explicitly for clarity during benchmark runs
+
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 3 # Short duration for benchmarking purposes
+  gradient_clipping: 1.0
+  random_seed: 42
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 500 # Example, adjust based on total steps if used for real pre-training
+    min_lr: 0.000005
+  # checkpoint_dir will be set by experiment_runner or a main script
+  # results_dir will be set by experiment_runner or a main script
+
+logging:
+  log_level: "INFO"
+  log_file: "bench_pas_seq512.log"

--- a/my_attention_research_project/configs/benchmarking/bench_vanilla_mha_seq1024.yaml
+++ b/my_attention_research_project/configs/benchmarking/bench_vanilla_mha_seq1024.yaml
@@ -1,0 +1,44 @@
+# Base parameters for benchmarking configurations
+# experiment_name will be set by the runner, usually based on filename
+
+model:
+  d_model: 256
+  num_encoder_layers: 4
+  ffn_dim_factor: 4
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+  # vocab_size will be set by the experiment_runner.py based on the tokenizer
+
+  # Attention specific configuration will be added below by each file
+  attention:
+    type: "VanillaMHA"
+    n_heads: 4 # d_model 256 / 4 heads = head_dim 64
+    dropout_rate: 0.1 # Can be same as global or specific
+
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 1024
+  batch_size: 16 
+  data_dir: "./data/processed/wikitext-103" # Path to processed data
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json" # Path to tokenizer
+  # tokenizer_max_length is usually in config['data'] and used by preprocessing.
+  # Should be >= sequence_length. If not set, a default is used in wikitext103.py.
+  tokenizer_max_length: 1024 # Set explicitly for clarity during benchmark runs
+
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 3 # Short duration for benchmarking purposes
+  gradient_clipping: 1.0
+  random_seed: 42
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 500 # Example, adjust based on total steps if used for real pre-training
+    min_lr: 0.000005
+  # checkpoint_dir will be set by experiment_runner or a main script
+  # results_dir will be set by experiment_runner or a main script
+
+logging:
+  log_level: "INFO"
+  log_file: "bench_vanilla_mha_seq1024.log"

--- a/my_attention_research_project/configs/benchmarking/bench_vanilla_mha_seq2048.yaml
+++ b/my_attention_research_project/configs/benchmarking/bench_vanilla_mha_seq2048.yaml
@@ -1,0 +1,44 @@
+# Base parameters for benchmarking configurations
+# experiment_name will be set by the runner, usually based on filename
+
+model:
+  d_model: 256
+  num_encoder_layers: 4
+  ffn_dim_factor: 4
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+  # vocab_size will be set by the experiment_runner.py based on the tokenizer
+
+  # Attention specific configuration will be added below by each file
+  attention:
+    type: "VanillaMHA"
+    n_heads: 4 # d_model 256 / 4 heads = head_dim 64
+    dropout_rate: 0.1 # Can be same as global or specific
+
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 2048
+  batch_size: 8 
+  data_dir: "./data/processed/wikitext-103" # Path to processed data
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json" # Path to tokenizer
+  # tokenizer_max_length is usually in config['data'] and used by preprocessing.
+  # Should be >= sequence_length. If not set, a default is used in wikitext103.py.
+  tokenizer_max_length: 2048 # Set explicitly for clarity during benchmark runs
+
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 3 # Short duration for benchmarking purposes
+  gradient_clipping: 1.0
+  random_seed: 42
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 500 # Example, adjust based on total steps if used for real pre-training
+    min_lr: 0.000005
+  # checkpoint_dir will be set by experiment_runner or a main script
+  # results_dir will be set by experiment_runner or a main script
+
+logging:
+  log_level: "INFO"
+  log_file: "bench_vanilla_mha_seq2048.log"

--- a/my_attention_research_project/configs/benchmarking/bench_vanilla_mha_seq4096.yaml
+++ b/my_attention_research_project/configs/benchmarking/bench_vanilla_mha_seq4096.yaml
@@ -1,0 +1,44 @@
+# Base parameters for benchmarking configurations
+# experiment_name will be set by the runner, usually based on filename
+
+model:
+  d_model: 256
+  num_encoder_layers: 4
+  ffn_dim_factor: 4
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+  # vocab_size will be set by the experiment_runner.py based on the tokenizer
+
+  # Attention specific configuration will be added below by each file
+  attention:
+    type: "VanillaMHA"
+    n_heads: 4 # d_model 256 / 4 heads = head_dim 64
+    dropout_rate: 0.1 # Can be same as global or specific
+
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 4096
+  batch_size: 4 
+  data_dir: "./data/processed/wikitext-103" # Path to processed data
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json" # Path to tokenizer
+  # tokenizer_max_length is usually in config['data'] and used by preprocessing.
+  # Should be >= sequence_length. If not set, a default is used in wikitext103.py.
+  tokenizer_max_length: 4096 # Set explicitly for clarity during benchmark runs
+
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 3 # Short duration for benchmarking purposes
+  gradient_clipping: 1.0
+  random_seed: 42
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 500 # Example, adjust based on total steps if used for real pre-training
+    min_lr: 0.000005
+  # checkpoint_dir will be set by experiment_runner or a main script
+  # results_dir will be set by experiment_runner or a main script
+
+logging:
+  log_level: "INFO"
+  log_file: "bench_vanilla_mha_seq4096.log"

--- a/my_attention_research_project/configs/benchmarking/bench_vanilla_mha_seq512.yaml
+++ b/my_attention_research_project/configs/benchmarking/bench_vanilla_mha_seq512.yaml
@@ -1,0 +1,44 @@
+# Base parameters for benchmarking configurations
+# experiment_name will be set by the runner, usually based on filename
+
+model:
+  d_model: 256
+  num_encoder_layers: 4
+  ffn_dim_factor: 4
+  dropout_rate: 0.1 # General dropout for FFN, embeddings, etc.
+  use_positional_embeddings: True
+  # vocab_size will be set by the experiment_runner.py based on the tokenizer
+
+  # Attention specific configuration will be added below by each file
+  attention:
+    type: "VanillaMHA"
+    n_heads: 4 # d_model 256 / 4 heads = head_dim 64
+    dropout_rate: 0.1 # Can be same as global or specific
+
+data:
+  dataset_name: "WikiText103"
+  sequence_length: 512
+  batch_size: 16 # Smaller batch size for potentially larger models or limited GPU memory during benchmark
+  data_dir: "./data/processed/wikitext-103" # Path to processed data
+  tokenizer_path: "./data/tokenizers/wikitext103_bpe.tokenizer.json" # Path to tokenizer
+  # tokenizer_max_length is usually in config['data'] and used by preprocessing.
+  # Should be >= sequence_length. If not set, a default is used in wikitext103.py.
+  tokenizer_max_length: 512 # Set explicitly for clarity during benchmark runs
+
+training:
+  optimizer: "AdamW"
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  num_epochs: 3 # Short duration for benchmarking purposes
+  gradient_clipping: 1.0
+  random_seed: 42
+  lr_scheduler:
+    type: "cosine_annealing"
+    warmup_steps: 500 # Example, adjust based on total steps if used for real pre-training
+    min_lr: 0.000005
+  # checkpoint_dir will be set by experiment_runner or a main script
+  # results_dir will be set by experiment_runner or a main script
+
+logging:
+  log_level: "INFO"
+  log_file: "bench_vanilla_mha_seq512.log"

--- a/my_attention_research_project/data/wikitext103.py
+++ b/my_attention_research_project/data/wikitext103.py
@@ -6,50 +6,70 @@ from torch.utils.data import Dataset, DataLoader
 from pathlib import Path
 import shutil # For robust directory removal in examples
 import json # For saving/loading processed data list
+import os
+import logging
+import requests
+import zipfile
+import io
 
 # Import from the project's tokenizer.py
 from .tokenizer import load_tokenizer, tokenize_function 
 
+# Setup basic logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+WIKITEXT103_URL = "https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-103-raw-v1.zip"
+EXPECTED_RAW_FILES = ["wiki.train.raw", "wiki.valid.raw", "wiki.test.raw"]
+
 def download_raw_text_files(raw_data_dir: str) -> None:
     """
-    Creates dummy raw text files (train.txt, valid.txt, test.txt) in the specified directory.
-    This simulates a dataset download for easier testing.
+    Downloads and extracts the WikiText-103 raw text files into the specified directory.
 
     Args:
-        raw_data_dir (str): Path to the directory where raw text files will be created.
+        raw_data_dir (str): Path to the directory where raw text files will be extracted.
     """
-    print(f"Creating dummy raw text files in {raw_data_dir}...")
-    Path(raw_data_dir).mkdir(parents=True, exist_ok=True)
+    raw_data_path = Path(raw_data_dir)
+    raw_data_path.mkdir(parents=True, exist_ok=True)
 
-    dummy_train_text = (
-        "Chapter 1: The Beginning.\nIt was a dark and stormy night. The wind howled, and rain lashed against the window panes. "
-        "Inside, by the fireplace, sat a lone figure, pondering the mysteries of the universe. "
-        "This text is meant for training. It needs to be long enough to create multiple sequences. "
-        "Causal language modeling is a fascinating subject. We predict the next token given previous tokens. "
-        "Let's add more sentences to make this sufficiently long for our dummy dataset. "
-        + ("This is a repeated sentence for length. " * 100)
-        + "End of training chapter 1."
-    )
-    (Path(raw_data_dir) / "train.txt").write_text(dummy_train_text, encoding='utf-8')
+    # Check if files already exist
+    files_exist = all((raw_data_path / fname).exists() for fname in EXPECTED_RAW_FILES)
+    if files_exist:
+        logging.info(f"WikiText-103 raw files already exist in {raw_data_dir}. Skipping download.")
+        return
 
-    dummy_valid_text = (
-        "Chapter 1: Validation Passages.\nValidation text helps tune hyperparameters. It should be different from the training set. "
-        "Consider this a new chapter, exploring similar themes but with different words. "
-        "The figure by the fireplace stirred, a new thought dawning. "
-        + ("This is a repeated validation sentence. " * 50)
-        + "End of validation chapter 1."
-    )
-    (Path(raw_data_dir) / "valid.txt").write_text(dummy_valid_text, encoding='utf-8')
+    logging.info(f"Downloading WikiText-103 raw data from {WIKITEXT103_URL}...")
+    try:
+        response = requests.get(WIKITEXT103_URL, stream=True)
+        response.raise_for_status()  # Raise an exception for bad status codes
 
-    dummy_test_text = (
-        "Chapter 1: The Final Test.\nTest data provides the final evaluation. It must not be seen during training or validation. "
-        "The storm had passed, and a quiet dawn approached. The answers were becoming clear. "
-        + ("This is a repeated test sentence. " * 50)
-        + "End of test chapter 1."
-    )
-    (Path(raw_data_dir) / "test.txt").write_text(dummy_test_text, encoding='utf-8')
-    
-    print(f"Created dummy files: train.txt, valid.txt, test.txt in {raw_data_dir}")
+        logging.info("Download complete. Extracting files...")
+        with zipfile.ZipFile(io.BytesIO(response.content)) as z:
+            # The zip file contains a top-level directory "wikitext-103-raw/"
+            # We need to extract files from this directory into raw_data_dir directly.
+            for member_info in z.infolist():
+                # Check if the member is one of the files we want and is inside the top-level folder
+                # e.g., "wikitext-103-raw/wiki.train.raw"
+                parts = Path(member_info.filename).parts
+                if len(parts) > 1 and parts[0] == "wikitext-103-raw" and parts[1] in EXPECTED_RAW_FILES:
+                    # Extract the file, stripping the top-level directory
+                    file_content = z.read(member_info.filename)
+                    target_path = raw_data_path / parts[1]
+                    with open(target_path, 'wb') as f:
+                        f.write(file_content)
+                    logging.info(f"Extracted {parts[1]} to {target_path}")
+        
+        logging.info(f"WikiText-103 raw files successfully downloaded and extracted to {raw_data_dir}")
+
+    except requests.exceptions.RequestException as e:
+        logging.error(f"Error downloading WikiText-103: {e}")
+        raise
+    except zipfile.BadZipFile as e:
+        logging.error(f"Error extracting zip file for WikiText-103: {e}")
+        raise
+    except Exception as e:
+        logging.error(f"An unexpected error occurred during download/extraction: {e}")
+        raise
+
 
 def preprocess_text_files_for_causal_lm(
     raw_data_dir: str, 
@@ -58,85 +78,77 @@ def preprocess_text_files_for_causal_lm(
     config: dict
 ) -> None:
     """
-    Processes raw text files for Causal Language Modeling.
-    Each raw text file (train.txt, valid.txt, test.txt) is tokenized
+    Processes raw text files (WikiText-103 format) for Causal Language Modeling.
+    Each raw text file (wiki.train.raw, etc.) is tokenized
     and its entire content is saved as a single JSON line in a corresponding .jsonl file.
 
     Args:
-        raw_data_dir (str): Directory containing raw text files (train.txt, etc.).
+        raw_data_dir (str): Directory containing raw text files (wiki.train.raw, etc.).
         processed_data_dir (str): Directory to save the processed .jsonl files.
         tokenizer_name_or_path (str): Name or path of the Hugging Face tokenizer.
         config (dict): Configuration dictionary, expected to contain:
                        `config['data']['tokenizer_max_length']`
-                       `config['data']['sequence_length']` (though not directly used here, good for context)
     """
-    print(f"Preprocessing text files from {raw_data_dir} to {processed_data_dir} for Causal LM...")
+    logging.info(f"Preprocessing text files from {raw_data_dir} to {processed_data_dir} for Causal LM...")
     Path(processed_data_dir).mkdir(parents=True, exist_ok=True)
 
-    tokenizer_max_len = config.get('data', {}).get('tokenizer_max_length', 1024)
-    print(f"Using tokenizer: {tokenizer_name_or_path} with max_length: {tokenizer_max_len}")
+    tokenizer_max_len = config.get('data', {}).get('tokenizer_max_length', 1024) # Default from original file
+    logging.info(f"Using tokenizer: {tokenizer_name_or_path} with max_length: {tokenizer_max_len}")
     tokenizer = load_tokenizer(tokenizer_name_or_path, max_length=tokenizer_max_len)
 
-    for split in ["train", "valid", "test"]:
-        raw_file_path = Path(raw_data_dir) / f"{split}.txt"
-        processed_file_path = Path(processed_data_dir) / f"{split}.jsonl"
+    # Determine actual filenames based on splits
+    # WikiText-103 uses 'train', 'valid', 'test' for its splits.
+    # The raw files are e.g. 'wiki.train.raw'.
+    # The output processed files will be 'train.jsonl', 'valid.jsonl', 'test.jsonl'.
+    split_to_raw_filename = {
+        "train": "wiki.train.raw",
+        "valid": "wiki.valid.raw",
+        "test": "wiki.test.raw"
+    }
+
+    for split, raw_filename in split_to_raw_filename.items():
+        raw_file_path = Path(raw_data_dir) / raw_filename
+        processed_file_path = Path(processed_data_dir) / f"{split}.jsonl" # Output remains train.jsonl etc.
 
         if not raw_file_path.exists():
-            print(f"Warning: Raw file {raw_file_path} not found. Skipping preprocessing for this split.")
+            logging.warning(f"Raw file {raw_file_path} not found. Skipping preprocessing for this split.")
             continue
 
-        print(f"Processing {raw_file_path}...")
+        logging.info(f"Processing {raw_file_path}...")
         text_content = raw_file_path.read_text(encoding='utf-8')
 
         if not text_content.strip():
-            print(f"Warning: Raw file {raw_file_path} is empty or contains only whitespace. Skipping.")
+            logging.warning(f"Raw file {raw_file_path} is empty or contains only whitespace. Skipping.")
             continue
         
-        # Tokenize the entire content of the file.
-        # Using do_not_pad as we are tokenizing the whole file, then chunking in Dataset.
-        # Truncation is important if file content > tokenizer_max_len.
         tokenized_data = tokenize_function(
             text_content, 
             tokenizer, 
-            max_length=tokenizer_max_len, # This will truncate if file content is too long
-            padding_strategy="do_not_pad", # No padding, we get one long sequence
-            truncation_strategy=True
+            max_length=tokenizer_max_len, 
+            padding_strategy="do_not_pad", 
+            truncation_strategy=True 
         )
         
         input_ids_list = tokenized_data["input_ids"].tolist()
         attention_mask_list = tokenized_data["attention_mask"].tolist()
 
-        # Save as a single JSON line in the .jsonl file
         with open(processed_file_path, 'w', encoding='utf-8') as f:
             json_record = {"input_ids": input_ids_list, "attention_mask": attention_mask_list}
             f.write(json.dumps(json_record) + '\n')
         
-        print(f"Saved processed data for {split} to {processed_file_path} ({len(input_ids_list)} tokens).")
+        logging.info(f"Saved processed data for {split} to {processed_file_path} ({len(input_ids_list)} tokens).")
 
-    print("Preprocessing complete.")
+    logging.info("Preprocessing complete.")
 
 
 class CausalLMTrainingDataset(Dataset):
     def __init__(self, file_path: str, sequence_length: int, pad_token_id: int):
-        """
-        Dataset for Causal Language Modeling.
-        Reads a .jsonl file where each line contains tokenized 'input_ids' and 'attention_mask'
-        for an entire dataset split (e.g., all training text).
-        This Dataset class then chunks this long sequence into smaller, fixed-length sequences.
-
-        Args:
-            file_path (str): Path to the processed .jsonl file (e.g., train.jsonl).
-                             Expects a single JSON line in the file.
-            sequence_length (int): The length of sequences to return.
-            pad_token_id (int): The ID of the PAD token from the tokenizer, used for padding if needed
-                                (though not explicitly used for padding here, good for context).
-        """
-        print(f"Initializing CausalLMTrainingDataset from: {file_path}, sequence_length: {sequence_length}")
+        logging.info(f"Initializing CausalLMTrainingDataset from: {file_path}, sequence_length: {sequence_length}")
         if not Path(file_path).exists():
             raise FileNotFoundError(f"Processed data file not found: {file_path}")
 
         with open(file_path, 'r', encoding='utf-8') as f:
-            line = f.readline() # Expecting only one line for the entire split
+            line = f.readline() 
             if not line:
                 raise ValueError(f"Processed data file {file_path} is empty.")
             try:
@@ -148,14 +160,13 @@ class CausalLMTrainingDataset(Dataset):
         self.attention_mask = torch.tensor(data_record['attention_mask'], dtype=torch.long)
         
         self.sequence_length = sequence_length
-        self.pad_token_id = pad_token_id # Stored for reference, might be useful later
+        self.pad_token_id = pad_token_id 
 
         if self.input_ids.dim() != 1 or self.attention_mask.dim() != 1:
             raise ValueError("Loaded 'input_ids' and 'attention_mask' must be 1D tensors (lists in JSON).")
         if self.input_ids.size(0) != self.attention_mask.size(0):
             raise ValueError("'input_ids' and 'attention_mask' must have the same length.")
 
-        # Ensure at least one example by padding if necessary
         min_tokens = self.sequence_length + 1
         if self.input_ids.size(0) < min_tokens:
             pad_len = min_tokens - self.input_ids.size(0)
@@ -163,41 +174,22 @@ class CausalLMTrainingDataset(Dataset):
             pad_attn = torch.zeros((pad_len,), dtype=torch.long)
             self.input_ids = torch.cat([self.input_ids, pad_ids], dim=0)
             self.attention_mask = torch.cat([self.attention_mask, pad_attn], dim=0)
-            print(f"Padded dataset to {min_tokens} tokens for sequence length {self.sequence_length}.")
+            logging.info(f"Padded dataset to {min_tokens} tokens for sequence length {self.sequence_length}.")
 
-        # Calculate the number of examples. We drop any extra tokens beyond full sequences.
-        # Each example is sequence_length tokens input and sequence_length tokens target (shifted by 1).
         self.num_examples = (self.input_ids.size(0) - 1) // self.sequence_length
-        print(f"Dataset loaded. Total tokens: {self.input_ids.size(0)}. Num examples for seq_len {self.sequence_length}: {self.num_examples}")
+        logging.info(f"Dataset loaded. Total tokens: {self.input_ids.size(0)}. Num examples for seq_len {self.sequence_length}: {self.num_examples}")
 
     def __len__(self):
         return self.num_examples
 
     def __getitem__(self, idx):
-        """
-        Returns a dictionary `{"input_ids": ..., "attention_mask": ..., "labels": ...}`.
-        'labels' are the target_ids, with padding tokens masked to -100.
-        """
         start_index = idx * self.sequence_length
-        # Slice to get sequence_length + 1 tokens to form input and target
-        # This chunk contains tokens for both input and the target (shifted by one)
         end_index = start_index + self.sequence_length + 1
         full_chunk = self.input_ids[start_index:end_index]
         
         input_ids_chunk = full_chunk[:-1]
-        target_ids_chunk = full_chunk[1:].clone() # Clone to modify for labels
-
-        # Fetch the corresponding attention mask for the input sequence
-        # This mask indicates real tokens (1) vs padding (0) in the original tokenized stream.
-        # Note: If preprocess used do_not_pad and truncate, attention_mask for the loaded part should be all 1s
-        # up to the truncation length of the original file.
+        target_ids_chunk = full_chunk[1:].clone() 
         attention_mask_chunk = self.attention_mask[start_index : start_index + self.sequence_length]
-
-        # Create labels: where attention_mask_chunk is 0 (padding in source), set target_ids to -100
-        # This is crucial for Causal LM if the original long sequence had padding due to truncation
-        # by tokenizer_max_length when the whole file was tokenized.
-        # If using 'do_not_pad' and the source text was shorter than tokenizer_max_length,
-        # the attention_mask for actual tokens will be all 1s.
         target_ids_chunk.masked_fill_(attention_mask_chunk == 0, -100)
         
         return {
@@ -207,95 +199,77 @@ class CausalLMTrainingDataset(Dataset):
         }
 
 if __name__ == '__main__':
-    print("Text Dataset Utilities example usage:")
+    print("Text Dataset Utilities example usage (WikiText-103):")
     
-    main_example_dir_name = "text_dataset_utils_example_run"
+    main_example_dir_name = "wikitext103_dataset_example_run" # Changed for clarity
     base_dir = Path("./data") / main_example_dir_name
-    raw_dir = base_dir / "raw_text"
-    processed_dir = base_dir / "processed_text_for_causal_lm"
+    raw_dir = base_dir / "raw_wikitext103" # Changed for clarity
+    processed_dir = base_dir / "processed_wikitext103_for_causal_lm" # Changed for clarity
     
-    # Ensure a clean state for the example run
     if base_dir.exists():
         shutil.rmtree(base_dir)
     
-    # Config for the example
-    # For GPT-2, pad_token_id is often the same as eos_token_id (e.g., 50256)
-    # We will fetch it from the tokenizer after loading.
     example_config = {
         'data': {
             'sequence_length': 64, 
-            'tokenizer_max_length': 256 # Smaller for faster example processing of dummy text
-        },
-        'model': { # This section might be for model parameters, but we use pad_token_id from tokenizer
-            # 'pad_token_id': 50256 # Placeholder, will be set by tokenizer
+            'tokenizer_max_length': 1024 # Larger for real data, but example uses subset
         }
     }
     tokenizer_name_for_example = "gpt2" 
 
     try:
-        # 1. "Download" raw text files (creates dummy files)
         download_raw_text_files(str(raw_dir))
 
-        # 2. Preprocess text files
-        preprocess_text_files_for_causal_lm(
-            raw_data_dir=str(raw_dir),
-            processed_data_dir=str(processed_dir),
-            tokenizer_name_or_path=tokenizer_name_for_example,
-            config=example_config
-        )
-
-        # 3. Instantiate Dataset and DataLoader
-        # Load tokenizer once to get pad_token_id for the Dataset
-        # This ensures pad_token_id is consistent with the tokenizer used for preprocessing.
-        temp_tokenizer = load_tokenizer(tokenizer_name_for_example)
-        pad_token_id_for_dataset = temp_tokenizer.pad_token_id
-        if pad_token_id_for_dataset is None: # Should be handled by load_tokenizer, but as a safeguard
-            pad_token_id_for_dataset = temp_tokenizer.eos_token_id if temp_tokenizer.eos_token_id is not None else 0
-            print(f"Warning: PAD token ID was None, using EOS or 0: {pad_token_id_for_dataset}")
-        del temp_tokenizer # No longer needed
-
-        train_jsonl_path = processed_dir / "train.jsonl"
-        if train_jsonl_path.exists():
-            dataset = CausalLMTrainingDataset(
-                file_path=str(train_jsonl_path), 
-                sequence_length=example_config['data']['sequence_length'],
-                pad_token_id=pad_token_id_for_dataset
-            )
-            
-            if len(dataset) > 0:
-                dataloader = DataLoader(dataset, batch_size=2)
-                print(f"\nCreated CausalLMTrainingDataset with {len(dataset)} examples.")
-                
-                first_batch = next(iter(dataloader))
-                print("\nFirst batch details:")
-                print(f"  Input IDs shape: {first_batch['input_ids'].shape}")   # Expected: [batch_size, sequence_length]
-                print(f"  Attention Mask shape: {first_batch['attention_mask'].shape}") # Expected: [batch_size, sequence_length]
-                print(f"  Labels shape: {first_batch['labels'].shape}")         # Expected: [batch_size, sequence_length]
-                
-                print("\nSample from first batch:")
-                print(f"  Input IDs (sample 0): {first_batch['input_ids'][0][:20]}...") # Print first 20 tokens
-                print(f"  Attention Mask (sample 0): {first_batch['attention_mask'][0][:20]}...")
-                print(f"  Labels (sample 0): {first_batch['labels'][0][:20]}...")
-                # Check if -100 is present in labels where attention mask might be 0 (if any padding occurred)
-                # For this dummy data and 'do_not_pad' with sufficient tokenizer_max_length, mask should be all 1s.
-                if (first_batch['labels'] == -100).any():
-                    print("  Note: -100 found in labels, indicating masked tokens.")
-                else:
-                    print("  Note: No -100 found in labels for this batch (likely no padding in source chunk or mask is all 1s).")
-
-            else:
-                print("Dataset created but contains no examples. Dummy data might be too short or seq_len too long.")
+        # Validate download
+        if not all((Path(raw_dir) / fname).exists() for fname in EXPECTED_RAW_FILES):
+            print(f"Error: Not all expected files were found in {raw_dir} after download attempt.")
         else:
-            print(f"Processed training file {train_jsonl_path} not found. Cannot create dataset.")
+            print(f"Successfully found expected raw files in {raw_dir}")
+
+            preprocess_text_files_for_causal_lm(
+                raw_data_dir=str(raw_dir),
+                processed_data_dir=str(processed_dir),
+                tokenizer_name_or_path=tokenizer_name_for_example,
+                config=example_config
+            )
+
+            temp_tokenizer = load_tokenizer(tokenizer_name_for_example)
+            pad_token_id_for_dataset = temp_tokenizer.pad_token_id
+            if pad_token_id_for_dataset is None:
+                pad_token_id_for_dataset = temp_tokenizer.eos_token_id if temp_tokenizer.eos_token_id is not None else 0
+            del temp_tokenizer
+
+            train_jsonl_path = processed_dir / "train.jsonl"
+            if train_jsonl_path.exists():
+                dataset = CausalLMTrainingDataset(
+                    file_path=str(train_jsonl_path), 
+                    sequence_length=example_config['data']['sequence_length'],
+                    pad_token_id=pad_token_id_for_dataset
+                )
+                
+                if len(dataset) > 0:
+                    dataloader = DataLoader(dataset, batch_size=2)
+                    print(f"\nCreated CausalLMTrainingDataset with {len(dataset)} examples.")
+                    first_batch = next(iter(dataloader))
+                    print("\nFirst batch details:")
+                    print(f"  Input IDs shape: {first_batch['input_ids'].shape}")
+                    print(f"  Attention Mask shape: {first_batch['attention_mask'].shape}")
+                    print(f"  Labels shape: {first_batch['labels'].shape}")
+                else:
+                    print("Dataset created but contains no examples.")
+            else:
+                print(f"Processed training file {train_jsonl_path} not found.")
 
     except Exception as e:
         print(f"An error occurred in the example usage: {e}")
         import traceback
         traceback.print_exc()
     finally:
-        # Clean up dummy files and directories
         if base_dir.exists():
-            shutil.rmtree(base_dir)
-            print(f"\nCleaned up example directory: {base_dir}")
+            # shutil.rmtree(base_dir) # Comment out to inspect files after run
+            print(f"\nClean up of {base_dir} skipped for inspection.")
+        else:
+            print(f"\nBase directory {base_dir} does not exist, no cleanup needed or already cleaned.")
+
 
     print("\nText Dataset Utilities example finished.")

--- a/my_attention_research_project/models/attention/moae_attention.py
+++ b/my_attention_research_project/models/attention/moae_attention.py
@@ -1,1 +1,252 @@
-# Placeholder for moae_attention.py
+import torch
+import torch.nn as nn
+import torch.nn.functional as F # For softmax
+from my_attention_research_project.models.attention.vanilla_mha import MultiHeadAttention
+# Placeholder for other expert imports like PASAttention if MOAE were to support them
+# from .pas_attention import PASAttention 
+
+class SoftGateMLP(nn.Module):
+    """
+    A simple MLP-based soft gating mechanism for MOAE.
+    It takes token embeddings and produces a probability distribution over experts for each token.
+    """
+    def __init__(self, 
+                 embed_dim: int, 
+                 num_experts: int, 
+                 hidden_dim: int = None, 
+                 dropout_rate: float = 0.0):
+        """
+        Initializes the SoftGateMLP module.
+
+        Args:
+            embed_dim: The dimensionality of the input token embeddings.
+            num_experts: The number of experts to gate over.
+            hidden_dim: The dimensionality of the hidden layer in the MLP.
+                        If None, defaults to embed_dim.
+            dropout_rate: Dropout rate to be applied within the MLP.
+        """
+        super().__init__()
+        self.num_experts = num_experts
+        
+        if hidden_dim is None:
+            hidden_dim = embed_dim
+        
+        self.fc1 = nn.Linear(embed_dim, hidden_dim)
+        self.activation = nn.ReLU()
+        self.dropout = nn.Dropout(dropout_rate)
+        self.fc2 = nn.Linear(hidden_dim, num_experts)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Performs the forward pass of the SoftGateMLP.
+
+        Args:
+            x: Input tensor of shape (batch_size, seq_len, embed_dim).
+
+        Returns:
+            gate_weights: Tensor of shape (batch_size, seq_len, num_experts),
+                          representing the probability distribution over experts for each token.
+        """
+        x = self.fc1(x)
+        x = self.activation(x)
+        x = self.dropout(x)
+        x = self.fc2(x)
+        gate_weights = F.softmax(x, dim=-1)
+        return gate_weights
+
+class MOAEAttention(nn.Module):
+    """
+    Implements the Mixture of Attention Experts (MOAE) mechanism.
+    This class will route inputs to different attention 'expert' modules
+    and combine their outputs using a gating mechanism.
+    """
+    def __init__(self, 
+                 d_model: int, 
+                 expert_configs: list[dict], 
+                 gating_config: dict, 
+                 dropout_rate: float = 0.0):
+        """
+        Initializes the MOAEAttention module.
+        """
+        super().__init__()
+        self.d_model = d_model
+        self.expert_configs = expert_configs 
+        self.gating_config = gating_config
+        self.dropout_rate = dropout_rate 
+
+        self.experts = nn.ModuleList()
+        for exp_conf in self.expert_configs:
+            expert_type = exp_conf.get("type")
+            if expert_type == "local_window_mha":
+                n_heads = exp_conf.get("n_heads")
+                if n_heads is None:
+                    raise ValueError("n_heads is required for local_window_mha expert.")
+                window_size = exp_conf.get("window_size")
+                if window_size is None:
+                    raise ValueError("window_size is required for local_window_mha expert.")
+                expert_dropout_rate = exp_conf.get("dropout_rate", self.dropout_rate)
+                mha_expert = MultiHeadAttention(self.d_model, num_heads=n_heads, dropout_rate=expert_dropout_rate)
+                mha_expert.expert_type = "local_window_mha"
+                mha_expert.window_size = window_size
+                self.experts.append(mha_expert)
+
+            elif expert_type == "dilated_mha":
+                n_heads = exp_conf.get("n_heads")
+                if n_heads is None:
+                    raise ValueError("n_heads is required for dilated_mha expert.")
+                dilation_rate = exp_conf.get("dilation_rate")
+                if dilation_rate is None:
+                    raise ValueError("dilation_rate is required for dilated_mha expert.")
+                if not isinstance(dilation_rate, int) or dilation_rate < 1:
+                    raise ValueError("dilation_rate must be an integer >= 1.")
+                expert_dropout_rate = exp_conf.get("dropout_rate", self.dropout_rate)
+                mha_expert = MultiHeadAttention(self.d_model, num_heads=n_heads, dropout_rate=expert_dropout_rate)
+                mha_expert.expert_type = "dilated_mha"
+                mha_expert.dilation_rate = dilation_rate
+                self.experts.append(mha_expert)
+            else:
+                raise ValueError(f"Unsupported expert type: {expert_type} in expert_configs.")
+
+        # Instantiate Gating Network
+        gating_type = self.gating_config.get("type")
+        self.gating_network = None 
+
+        if gating_type == "soft_gate_mlp":
+            hidden_dim = self.gating_config.get("hidden_dim") 
+            gate_dropout_rate = self.gating_config.get("dropout_rate", self.dropout_rate)
+            num_experts = len(self.experts)
+
+            if num_experts == 0 and not self.expert_configs : # Allow no experts if expert_configs was empty
+                 pass # gating_network remains None if no experts from the start
+            elif num_experts == 0 and self.expert_configs : # This case means all expert configs failed to init
+                 raise ValueError("Gating network cannot be created as no experts were successfully initialized.")
+            elif num_experts > 0:
+                self.gating_network = SoftGateMLP(
+                    embed_dim=self.d_model,
+                    num_experts=num_experts,
+                    hidden_dim=hidden_dim, 
+                    dropout_rate=gate_dropout_rate
+                )
+        elif gating_type is None:
+             if self.expert_configs: # If experts were intended but no gating specified
+                raise ValueError("Gating type not specified in gating_config, but experts are present.")
+             # If no experts and no gating type, it's fine, gating_network is None
+        else:
+            raise NotImplementedError(f"Gating type '{gating_type}' not supported.")
+
+
+    def _generate_local_window_mask(self, 
+                                   seq_len: int, 
+                                   window_size: int, 
+                                   device: torch.device, 
+                                   batch_size: int = 1, 
+                                   input_padding_mask: torch.Tensor = None) -> torch.Tensor:
+        look_backward = window_size // 2
+        look_forward = window_size - 1 - look_backward
+        local_mask = torch.zeros(seq_len, seq_len, device=device, dtype=torch.bool)
+        for i in range(seq_len):
+            start = max(0, i - look_backward)
+            end = min(seq_len, i + look_forward + 1)
+            local_mask[i, start:end] = True
+        local_mask = local_mask.unsqueeze(0).unsqueeze(0).expand(batch_size, 1, seq_len, seq_len)
+        if input_padding_mask is not None:
+            if input_padding_mask.dim() != 2 or input_padding_mask.shape[0] != batch_size or input_padding_mask.shape[1] != seq_len:
+                raise ValueError(f"input_padding_mask shape must be ({batch_size}, {seq_len}), but got {input_padding_mask.shape}")
+            padding_mask_bool = input_padding_mask.bool() if input_padding_mask.dtype != torch.bool else input_padding_mask
+            expanded_padding_mask = padding_mask_bool.unsqueeze(1).unsqueeze(2)
+            final_mask = local_mask & expanded_padding_mask
+        else:
+            final_mask = local_mask
+        return final_mask
+
+    def _generate_dilated_mask(self, 
+                               seq_len: int, 
+                               dilation_rate: int, 
+                               device: torch.device, 
+                               batch_size: int = 1, 
+                               input_padding_mask: torch.Tensor = None) -> torch.Tensor:
+        if not isinstance(dilation_rate, int) or dilation_rate < 1:
+            raise ValueError("Dilation rate must be an integer >= 1")
+        dilated_key_indices = torch.arange(0, seq_len, dilation_rate, device=device, dtype=torch.long)
+        key_mask_1d = torch.zeros(seq_len, device=device, dtype=torch.bool)
+        key_mask_1d[dilated_key_indices] = True
+        dilated_mask = key_mask_1d.unsqueeze(0).expand(seq_len, seq_len) 
+        dilated_mask = dilated_mask.unsqueeze(0).unsqueeze(0).expand(batch_size, 1, seq_len, seq_len)
+        if input_padding_mask is not None:
+            if input_padding_mask.dim() != 2 or input_padding_mask.shape[0] != batch_size or input_padding_mask.shape[1] != seq_len:
+                raise ValueError(f"input_padding_mask shape must be ({batch_size}, {seq_len}), but got {input_padding_mask.shape}")
+            padding_mask_bool = input_padding_mask.bool() if input_padding_mask.dtype != torch.bool else input_padding_mask
+            expanded_padding_mask = padding_mask_bool.unsqueeze(1).unsqueeze(2)
+            final_mask = dilated_mask & expanded_padding_mask
+        else:
+            final_mask = dilated_mask
+        return final_mask
+
+
+    def forward(self, 
+                query: torch.Tensor, 
+                key: torch.Tensor, 
+                value: torch.Tensor, 
+                input_padding_mask: torch.Tensor = None) -> torch.Tensor:
+        
+        if not self.experts:
+            # If expert_configs was empty from the start, this is a valid "no-op" or identity if d_model matches.
+            # However, typically MOAE implies experts. If it was configured to have experts but none initialized,
+            # __init__ should have ideally caught it.
+            # For now, let's assume if self.experts is empty, it means no experts were configured.
+            # Depending on desired behavior, could return query or raise error.
+            # The prompt implies error if configured but empty.
+             raise RuntimeError("MOAEAttention has no experts configured.")
+
+        if self.gating_network is None:
+            # This implies either gating_type was None and no experts, or failed init.
+            # If experts exist but no gating, that's an issue.
+            raise RuntimeError("MOAEAttention has no gating network configured.")
+
+        batch_size, seq_len_q, _ = query.shape
+        _ , seq_len_k, _ = key.shape # key sequence length for masks
+        device = query.device
+
+        expert_outputs = []
+        for expert_module in self.experts:
+            expert_type = expert_module.expert_type
+            current_expert_mask = None
+
+            if expert_type == "local_window_mha":
+                current_expert_mask = self._generate_local_window_mask(
+                    seq_len_k, expert_module.window_size, device, batch_size, input_padding_mask)
+            elif expert_type == "dilated_mha":
+                current_expert_mask = self._generate_dilated_mask(
+                    seq_len_k, expert_module.dilation_rate, device, batch_size, input_padding_mask)
+            # Add elif blocks here for other expert types like "PAS" if they were fully integrated
+            # elif expert_type == "PAS":
+            #    # PASAttention might not use a pre-generated mask in the same way,
+            #    # or it might take input_padding_mask directly.
+            #    # Its call signature is (query, key, value, input_padding_mask)
+            #    # And it returns (context_vector, hotspot_indices)
+            #    expert_context, _ = expert_module(query, key, value, input_padding_mask=input_padding_mask)
+            #    expert_outputs.append(expert_context)
+            #    continue # Skip common MHA call below
+            else:
+                raise NotImplementedError(f"Mask generation or call for expert type {expert_type} not implemented in forward pass.")
+            
+            # Assuming MHA-like experts that return (context, weights)
+            expert_context, _ = expert_module(query, key, value, mask=current_expert_mask)
+            expert_outputs.append(expert_context)
+        
+        if not expert_outputs: # Should be caught by self.experts check, but as a safeguard
+            raise RuntimeError("No expert outputs were generated.")
+
+        # Stack expert outputs: (B, L_q, NumExperts, D)
+        stacked_expert_outputs = torch.stack(expert_outputs, dim=2) 
+        
+        # Get Gate Weights: (B, L_q, NumExperts)
+        gate_weights = self.gating_network(query) 
+        
+        # Combine Expert Outputs using einsum
+        # gate_weights: (B, L_q, NumExperts) -> 'bln'
+        # stacked_expert_outputs: (B, L_q, NumExperts, D) -> 'blnd'
+        # combined_context: (B, L_q, D) -> 'bld'
+        combined_context = torch.einsum('bln,blnd->bld', gate_weights, stacked_expert_outputs)
+        
+        return combined_context

--- a/my_attention_research_project/models/attention/pas_attention.py
+++ b/my_attention_research_project/models/attention/pas_attention.py
@@ -1,1 +1,195 @@
-# Placeholder for pas_attention.py
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from my_attention_research_project.models.attention.vanilla_mha import MultiHeadAttention
+
+class PASAttention(nn.Module):
+    """
+    Implements the Perceiver Attention Sampling (PAS) mechanism.
+    """
+    def __init__(self, 
+                 d_model: int, 
+                 scanner_config: dict, 
+                 focused_attention_config: dict, 
+                 dropout_rate: float = 0.0): # This dropout_rate is a general default
+        """
+        Initializes the PASAttention module.
+
+        Args:
+            d_model: The dimensionality of the input and output features.
+            scanner_config: Configuration dictionary for the scanner module.
+            focused_attention_config: Configuration dictionary for the focused attention module.
+            dropout_rate: Default dropout rate if not specified in focused_attention_config.
+        """
+        super().__init__()
+        self.d_model = d_model
+        self.scanner_config = scanner_config
+        self.focused_attention_config = focused_attention_config
+        # self.dropout_rate = dropout_rate # General dropout, not directly used here but stored if needed elsewhere
+
+        # Scanner initialization
+        if self.scanner_config.get("type") == "PAS_P1_linear":
+            self.scanner_q_proj = nn.Linear(self.d_model, self.d_model, bias=False)
+            self.scanner_k_proj = nn.Linear(self.d_model, self.d_model, bias=False)
+            self.top_k_hotspots = self.scanner_config.get("top_k_hotspots")
+            if self.top_k_hotspots is None:
+                raise ValueError("top_k_hotspots must be provided in scanner_config for PAS_P1_linear")
+            self.scanner = self._linear_scanner
+        else:
+            self.scanner = None 
+
+        # Focused Attention MHA initialization
+        mha_num_heads = self.focused_attention_config.get("num_heads")
+        if mha_num_heads is None:
+            raise ValueError("num_heads must be provided in focused_attention_config")
+        
+        # Use 0.0 as default for MHA dropout_rate if not specified in its config
+        mha_dropout_rate = self.focused_attention_config.get("dropout_rate", 0.0) 
+        
+        self.focused_attention_mha = MultiHeadAttention(
+            d_model=self.d_model, 
+            num_heads=mha_num_heads, 
+            dropout_rate=mha_dropout_rate
+        )
+        self.focused_attention = self._focused_sparse_attention
+
+
+    def _linear_scanner(self, 
+                        query_embed: torch.Tensor, 
+                        key_embed: torch.Tensor, 
+                        key_padding_mask: torch.Tensor = None) -> torch.Tensor:
+        """
+        Performs the linear scan to identify hotspots.
+        Args:
+            query_embed: Query tensor (batch_size, seq_len_q, d_model).
+            key_embed: Key tensor (batch_size, seq_len_k, d_model).
+            key_padding_mask: Padding mask for keys (batch_size, seq_len_k),
+                              where True or 1.0 indicates valid tokens, False or 0.0 for padding.
+        Returns:
+            hotspot_indices: Indices of the top_k hotspots (batch_size, seq_len_q, top_k_hotspots).
+        """
+        q_proj = self.scanner_q_proj(query_embed)
+        k_proj = self.scanner_k_proj(key_embed)
+
+        scores = torch.matmul(q_proj, k_proj.transpose(-2, -1))
+        scores = F.elu(scores) + 1
+
+        if key_padding_mask is not None:
+            mask = key_padding_mask.unsqueeze(1) # (batch_size, 1, seq_len_k)
+            if mask.dtype != torch.bool: 
+                mask = mask.bool()
+            scores = scores.masked_fill(mask == False, float('-inf'))
+
+        k_dim_size = scores.size(-1)
+        current_k = min(self.top_k_hotspots, k_dim_size)
+        
+        if k_dim_size == 0 : 
+            batch_size, seq_len_q, _ = query_embed.shape
+            return torch.empty((batch_size, seq_len_q, 0), dtype=torch.long, device=query_embed.device)
+
+        # If current_k is 0 (e.g. self.top_k_hotspots is 0), topk returns empty tensors.
+        # If all scores are -inf, topk still returns indices (they just correspond to -inf scores).
+        # The sparse attention mask will handle these 'invalid' selections.
+        _, hotspot_indices = torch.topk(scores, k=current_k, dim=-1)
+        
+        return hotspot_indices
+
+    def _focused_sparse_attention(self, 
+                                  query: torch.Tensor, 
+                                  key: torch.Tensor, 
+                                  value: torch.Tensor, 
+                                  hotspot_indices: torch.Tensor, 
+                                  original_key_padding_mask: torch.Tensor = None) -> torch.Tensor:
+        """
+        Performs focused sparse attention using the identified hotspots.
+        Args:
+            query: Query tensor (batch_size, seq_len_q, d_model).
+            key: Original full key sequence (batch_size, seq_len_k_orig, d_model).
+            value: Original full value sequence (batch_size, seq_len_k_orig, d_model).
+            hotspot_indices: Indices from Stage 1 (batch_size, seq_len_q, top_k_hotspots).
+            original_key_padding_mask: Padding mask for the original key sequence (batch_size, seq_len_k_orig).
+                                       True/1 for valid, False/0 for pad.
+        Returns:
+            context_vector: Output from the focused attention (batch_size, seq_len_q, d_model).
+        """
+        batch_size, seq_len_q, d_model_q = query.shape # d_model_q should be self.d_model
+        _, _, top_k = hotspot_indices.shape
+
+        if top_k == 0: # No hotspots selected (e.g. top_k_hotspots was 0 or seq_len_k was 0)
+            return torch.zeros_like(query)
+
+        expanded_hotspot_indices = hotspot_indices.unsqueeze(-1).expand(-1, -1, -1, self.d_model)
+
+        k_gathered = torch.gather(key.unsqueeze(1).expand(-1, seq_len_q, -1, -1), 
+                                  dim=2, 
+                                  index=expanded_hotspot_indices)
+        v_gathered = torch.gather(value.unsqueeze(1).expand(-1, seq_len_q, -1, -1), 
+                                  dim=2, 
+                                  index=expanded_hotspot_indices)
+
+        sparse_mask = torch.ones(batch_size, seq_len_q, top_k, device=query.device, dtype=torch.bool)
+
+        if original_key_padding_mask is not None:
+            # original_key_padding_mask: (B, S_k_orig), True for valid
+            # hotspot_indices: (B, S_q, top_k)
+            # gathered_padding_status: (B, S_q, top_k), True if original key at this hotspot index was valid
+            gathered_padding_status = torch.gather(
+                original_key_padding_mask.unsqueeze(1).expand(-1, seq_len_q, -1), 
+                dim=2, 
+                index=hotspot_indices
+            )
+            sparse_mask = sparse_mask & gathered_padding_status
+        
+        # sparse_mask: (batch_size, seq_len_q, top_k), True means attend, False means mask.
+        # MHA expects mask where False means "mask this position". This is consistent.
+        sparse_mask_for_mha = sparse_mask.unsqueeze(1).unsqueeze(2) # (B, 1, S_q, top_k)
+        
+        q_reshaped = query.contiguous().view(batch_size * seq_len_q, 1, self.d_model)
+        k_reshaped = k_gathered.contiguous().view(batch_size * seq_len_q, top_k, self.d_model)
+        v_reshaped = v_gathered.contiguous().view(batch_size * seq_len_q, top_k, self.d_model)
+        
+        # Mask for MHA: (B * S_q, 1, 1, top_k)
+        # Each of the (B * S_q) queries has length 1.
+        # The keys for each query have length top_k.
+        # The MHA mask should be (N, num_heads, L_q, L_k) or (N, L_q, L_k)
+        # Here N = B * S_q, L_q = 1, L_k = top_k
+        # So, mask_reshaped should be (B * S_q, 1, top_k) or (B*S_q, num_heads, 1, top_k)
+        # The prompt specifies mask_reshaped = sparse_mask_for_mha.view(batch_size * seq_len_q, 1, 1, top_k)
+        mask_reshaped = sparse_mask_for_mha.view(batch_size * seq_len_q, 1, 1, top_k)
+
+        context_reshaped, _ = self.focused_attention_mha(q_reshaped, k_reshaped, v_reshaped, mask=mask_reshaped)
+        
+        context_vector = context_reshaped.view(batch_size, seq_len_q, self.d_model)
+        return context_vector
+
+    def forward(self, 
+                query: torch.Tensor, 
+                key: torch.Tensor, 
+                value: torch.Tensor, 
+                input_padding_mask: torch.Tensor = None):
+        """
+        Performs the forward pass of the PASAttention module.
+
+        Args:
+            query: The query tensor (batch_size, seq_len_q, d_model).
+            key: The key tensor (batch_size, seq_len_k_orig, d_model).
+            value: The value tensor (batch_size, seq_len_k_orig, d_model).
+            input_padding_mask: An optional mask for input padding (batch_size, seq_len_k_orig).
+                                Assumed to be True/1 for valid, False/0 for padding.
+
+        Returns:
+            context_vector: The output tensor from the focused attention mechanism.
+            hotspot_indices: Indices of the top_k hotspots.
+        """
+        hotspot_indices = None
+        if self.scanner is not None:
+            hotspot_indices = self.scanner(query, key, input_padding_mask)
+        else:
+            raise NotImplementedError("Scanner is not configured, but PAS requires a scanner.")
+
+        if self.focused_attention is not None:
+            # Pass original_key_padding_mask (which is input_padding_mask) to focused attention
+            context_vector = self.focused_attention(query, key, value, hotspot_indices, input_padding_mask)
+            return context_vector, hotspot_indices
+        else:
+            raise NotImplementedError("Focused attention is not configured.")

--- a/my_attention_research_project/models/transformer.py
+++ b/my_attention_research_project/models/transformer.py
@@ -212,8 +212,55 @@ class TransformerEncoder(nn.Module):
                 d_model=d_model, 
                 **ahc_constructor_params # Pass all other AHC-specific params
             )
-        # Add elif blocks here for PASAttention, MOAEAttention when they are implemented
-        # e.g., elif attention_type == "PAS": from .attention.pas_attention import PASAttention ...
+        elif attention_type == "PAS":
+            try:
+                from .attention.pas_attention import PASAttention
+            except ImportError as e:
+                raise ImportError(
+                    f"Failed to import PASAttention for attention_type 'PAS'. "
+                    f"Ensure 'pas_attention.py' exists and is error-free. Original error: {e}"
+                )
+            
+            scanner_config = attention_config.get("scanner_config")
+            focused_attention_config = attention_config.get("focused_attention_config")
+            # Inherits from model's overall dropout_rate if not specified in PAS's part of attention_config
+            pas_dropout_rate = attention_config.get("dropout_rate", dropout_rate)
+
+            if scanner_config is None:
+                raise ValueError("scanner_config is required for PASAttention.")
+            if focused_attention_config is None:
+                raise ValueError("focused_attention_config is required for PASAttention.")
+
+            attention_module_instance = PASAttention(
+                d_model=d_model,
+                scanner_config=scanner_config,
+                focused_attention_config=focused_attention_config,
+                dropout_rate=pas_dropout_rate
+            )
+        elif attention_type == "MOAE":
+            try:
+                from .attention.moae_attention import MOAEAttention
+            except ImportError as e:
+                raise ImportError(
+                    f"Failed to import MOAEAttention for attention_type 'MOAE'. "
+                    f"Ensure 'moae_attention.py' exists and is error-free. Original error: {e}"
+                )
+
+            expert_configs = attention_config.get("expert_configs")
+            gating_config = attention_config.get("gating_config")
+            moae_dropout_rate = attention_config.get("dropout_rate", dropout_rate)
+
+            if not isinstance(expert_configs, list) or not expert_configs:
+                raise ValueError("expert_configs (list of dicts) is required for MOAEAttention and cannot be empty.")
+            if not isinstance(gating_config, dict): # Check if it's a dictionary
+                raise ValueError("gating_config (dict) is required for MOAEAttention.")
+            
+            attention_module_instance = MOAEAttention(
+                d_model=d_model,
+                expert_configs=expert_configs,
+                gating_config=gating_config,
+                dropout_rate=moae_dropout_rate
+            )
         else:
             raise ValueError(f"Unsupported attention_type in config: '{attention_type}'")
 

--- a/my_attention_research_project/tests/models/attention/test_moae_attention.py
+++ b/my_attention_research_project/tests/models/attention/test_moae_attention.py
@@ -1,0 +1,206 @@
+import unittest
+import torch
+import unittest.mock as mock # Added for mocking
+from my_attention_research_project.models.attention.moae_attention import MOAEAttention, SoftGateMLP
+from my_attention_research_project.models.attention.vanilla_mha import MultiHeadAttention
+
+class TestMOAEAttention(unittest.TestCase):
+    def setUp(self):
+        self.d_model = 32
+        self.batch_size = 2
+        self.seq_len = 10
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+        self.sample_expert_configs = [
+            {"type": "local_window_mha", "n_heads": 4, "window_size": 5, "dropout_rate": 0.0},
+            {"type": "dilated_mha", "n_heads": 2, "dilation_rate": 2, "dropout_rate": 0.0}
+        ]
+        self.sample_gating_config = {"type": "soft_gate_mlp", "hidden_dim": 64, "dropout_rate": 0.0}
+
+        self.query = torch.rand(self.batch_size, self.seq_len, self.d_model, device=self.device)
+        self.key = torch.rand(self.batch_size, self.seq_len, self.d_model, device=self.device)
+        self.value = torch.rand(self.batch_size, self.seq_len, self.d_model, device=self.device)
+        
+        self.moae_dummy_instance = MOAEAttention(
+            self.d_model, 
+            self.sample_expert_configs, 
+            self.sample_gating_config, 
+            0.0
+        ).to(self.device) # Ensure module is on the correct device
+        self.query = self.query.to(self.device)
+        self.key = self.key.to(self.device)
+        self.value = self.value.to(self.device)
+
+
+    # 2. Initialization Tests (from previous step)
+    def test_initialization_success(self):
+        moae_att = MOAEAttention(self.d_model, self.sample_expert_configs, self.sample_gating_config, 0.0)
+        self.assertEqual(len(moae_att.experts), len(self.sample_expert_configs))
+        self.assertIsInstance(moae_att.experts[0], MultiHeadAttention)
+        self.assertEqual(moae_att.experts[0].expert_type, "local_window_mha")
+        self.assertEqual(moae_att.experts[0].window_size, 5)
+        self.assertIsInstance(moae_att.experts[1], MultiHeadAttention)
+        self.assertEqual(moae_att.experts[1].expert_type, "dilated_mha")
+        self.assertEqual(moae_att.experts[1].dilation_rate, 2)
+        self.assertIsInstance(moae_att.gating_network, SoftGateMLP)
+
+    def test_initialization_invalid_expert_type(self):
+        invalid_expert_configs = [{"type": "unknown_expert", "n_heads": 4}]
+        with self.assertRaises(ValueError): 
+            MOAEAttention(self.d_model, invalid_expert_configs, self.sample_gating_config, 0.0)
+
+    def test_initialization_missing_expert_params(self):
+        configs_missing_n_heads = [{"type": "local_window_mha", "window_size": 5}] 
+        with self.assertRaises(ValueError):
+            MOAEAttention(self.d_model, configs_missing_n_heads, self.sample_gating_config, 0.0)
+        configs_missing_window_size = [{"type": "local_window_mha", "n_heads": 4}] 
+        with self.assertRaises(ValueError):
+            MOAEAttention(self.d_model, configs_missing_window_size, self.sample_gating_config, 0.0)
+        configs_missing_dilation_rate = [{"type": "dilated_mha", "n_heads": 2}] 
+        with self.assertRaises(ValueError):
+            MOAEAttention(self.d_model, configs_missing_dilation_rate, self.sample_gating_config, 0.0)
+
+    def test_initialization_invalid_gating_type(self):
+        invalid_gating_config = {"type": "unknown_gating"}
+        with self.assertRaises(NotImplementedError): 
+            MOAEAttention(self.d_model, self.sample_expert_configs, invalid_gating_config, 0.0)
+
+    def test_initialization_no_experts(self):
+        with self.assertRaises(ValueError): 
+            MOAEAttention(self.d_model, [], self.sample_gating_config, 0.0)
+
+    # 3. Mask Generation Helper Tests (_generate_local_window_mask) (from previous step)
+    def test_local_window_mask_shape_and_type(self):
+        mask = self.moae_dummy_instance._generate_local_window_mask(
+            self.seq_len, window_size=5, device=self.device, batch_size=self.batch_size)
+        self.assertEqual(mask.shape, (self.batch_size, 1, self.seq_len, self.seq_len))
+        self.assertEqual(mask.dtype, torch.bool)
+
+    def test_local_window_mask_values(self):
+        window_size = 3 
+        seq_len_test = 4
+        mask = self.moae_dummy_instance._generate_local_window_mask(
+            seq_len=seq_len_test, window_size=window_size, device=self.device, batch_size=1)
+        self.assertTrue(mask[0, 0, 0, 0]); self.assertTrue(mask[0, 0, 0, 1]); self.assertFalse(mask[0, 0, 0, 2]); self.assertFalse(mask[0, 0, 0, 3])
+        self.assertTrue(mask[0, 0, 1, 0]); self.assertTrue(mask[0, 0, 1, 1]); self.assertTrue(mask[0, 0, 1, 2]); self.assertFalse(mask[0, 0, 1, 3])
+        self.assertFalse(mask[0, 0, 2, 0]); self.assertTrue(mask[0, 0, 2, 1]); self.assertTrue(mask[0, 0, 2, 2]); self.assertTrue(mask[0, 0, 2, 3])
+        self.assertFalse(mask[0, 0, 3, 0]); self.assertFalse(mask[0, 0, 3, 1]); self.assertTrue(mask[0, 0, 3, 2]); self.assertTrue(mask[0, 0, 3, 3])
+
+    def test_local_window_mask_with_padding(self):
+        seq_len_test = 4; window_size = 3
+        input_pad = torch.tensor([[True, True, False, False]], device=self.device, dtype=torch.bool) 
+        mask = self.moae_dummy_instance._generate_local_window_mask(
+            seq_len_test, window_size, self.device, 1, input_pad)
+        self.assertFalse(torch.any(mask[0, 0, :, 2])); self.assertFalse(torch.any(mask[0, 0, :, 3]))
+        self.assertTrue(mask[0,0,0,0]); self.assertTrue(mask[0,0,0,1]); self.assertFalse(mask[0,0,0,2])
+        self.assertTrue(mask[0,0,1,0]); self.assertTrue(mask[0,0,1,1]); self.assertFalse(mask[0,0,1,2])
+
+    # 4. Mask Generation Helper Tests (_generate_dilated_mask) (from previous step)
+    def test_dilated_mask_shape_and_type(self):
+        mask = self.moae_dummy_instance._generate_dilated_mask(
+            self.seq_len, dilation_rate=2, device=self.device, batch_size=self.batch_size)
+        self.assertEqual(mask.shape, (self.batch_size, 1, self.seq_len, self.seq_len))
+        self.assertEqual(mask.dtype, torch.bool)
+
+    def test_dilated_mask_values(self):
+        dilation_rate = 2; seq_len_test = 5 
+        mask = self.moae_dummy_instance._generate_dilated_mask(seq_len_test, dilation_rate, self.device, 1)
+        expected_key_pattern = torch.tensor([True, False, True, False, True], device=self.device)
+        for i in range(seq_len_test): self.assertTrue(torch.equal(mask[0, 0, i, :], expected_key_pattern))
+
+    def test_dilated_mask_with_padding(self):
+        seq_len_test = 5; dilation_rate = 2
+        input_pad = torch.tensor([[True, True, False, True, False]], device=self.device, dtype=torch.bool) 
+        mask = self.moae_dummy_instance._generate_dilated_mask(seq_len_test, dilation_rate, self.device, 1, input_pad)
+        expected_key_pattern_after_padding = torch.tensor([True, False, False, False, False], device=self.device)
+        for i in range(seq_len_test): self.assertTrue(torch.equal(mask[0, 0, i, :], expected_key_pattern_after_padding))
+
+    # 5. Gating Mechanism (SoftGateMLP) Tests
+    def test_soft_gate_mlp_output(self):
+        num_experts_test = len(self.sample_expert_configs)
+        gate_mlp = SoftGateMLP(embed_dim=self.d_model, num_experts=num_experts_test, hidden_dim=64).to(self.device)
+        gate_weights = gate_mlp(self.query)
+        
+        self.assertEqual(gate_weights.shape, (self.batch_size, self.seq_len, num_experts_test))
+        self.assertTrue(torch.allclose(gate_weights.sum(dim=-1), torch.ones_like(gate_weights.sum(dim=-1))))
+        self.assertTrue(torch.all(gate_weights >= 0) and torch.all(gate_weights <= 1))
+
+    # 6. Individual Expert Forward Pass (within MOAEAttention context)
+    def test_expert_local_window_forward(self):
+        config = [{"type": "local_window_mha", "n_heads": 2, "window_size": 3, "dropout_rate": 0.0}]
+        gating_cfg = {"type": "soft_gate_mlp", "hidden_dim": 32, "dropout_rate": 0.0}
+        moae_att = MOAEAttention(self.d_model, config, gating_cfg, 0.0).to(self.device)
+        
+        expert = moae_att.experts[0]
+        mask = moae_att._generate_local_window_mask(
+            self.seq_len, expert.window_size, self.device, self.batch_size)
+        output, _ = expert(self.query, self.key, self.value, mask=mask)
+        self.assertEqual(output.shape, (self.batch_size, self.seq_len, self.d_model))
+
+    def test_expert_dilated_mha_forward(self):
+        config = [{"type": "dilated_mha", "n_heads": 2, "dilation_rate": 2, "dropout_rate": 0.0}]
+        gating_cfg = {"type": "soft_gate_mlp", "hidden_dim": 32, "dropout_rate": 0.0}
+        moae_att = MOAEAttention(self.d_model, config, gating_cfg, 0.0).to(self.device)
+
+        expert = moae_att.experts[0]
+        mask = moae_att._generate_dilated_mask(
+            self.seq_len, expert.dilation_rate, self.device, self.batch_size)
+        output, _ = expert(self.query, self.key, self.value, mask=mask)
+        self.assertEqual(output.shape, (self.batch_size, self.seq_len, self.d_model))
+
+    # 7. MOAEAttention Full Forward Pass Tests
+    def test_moae_forward_pass_shape(self):
+        moae_att = self.moae_dummy_instance # Uses self.sample_expert_configs
+        context = moae_att(self.query, self.key, self.value, None)
+        self.assertEqual(context.shape, (self.batch_size, self.seq_len, self.d_model))
+
+    def test_moae_forward_pass_with_padding(self):
+        moae_att = self.moae_dummy_instance
+        input_pad = torch.ones(self.batch_size, self.seq_len, device=self.device, dtype=torch.bool)
+        input_pad[:, -self.seq_len//2:] = False # Pad last half of keys/values
+        
+        context = moae_att(self.query, self.key, self.value, input_padding_mask=input_pad)
+        self.assertEqual(context.shape, (self.batch_size, self.seq_len, self.d_model))
+        # Further checks for padding influence are complex without known weights/outputs
+
+    def test_moae_forward_combination_logic(self):
+        single_expert_configs = [self.sample_expert_configs[0].copy()] # Local window expert
+        # Ensure gating config is compatible with 1 expert for SoftGateMLP
+        single_expert_gating_cfg = {"type": "soft_gate_mlp", "hidden_dim": 32, "dropout_rate": 0.0}
+        
+        moae_att = MOAEAttention(self.d_model, single_expert_configs, single_expert_gating_cfg, 0.0).to(self.device)
+
+        # Mock gating_network to return all weight to the single expert
+        # Softmax on [anything] for a single expert will result in [1.0]
+        moae_att.gating_network = mock.Mock(return_value=torch.ones(self.batch_size, self.seq_len, 1, device=self.device))
+        
+        expert_module = moae_att.experts[0]
+        the_mask_for_expert_0 = moae_att._generate_local_window_mask(
+            self.seq_len, expert_module.window_size, self.device, self.batch_size, None)
+        
+        expert_direct_output, _ = expert_module(self.query, self.key, self.value, mask=the_mask_for_expert_0)
+        moae_output = moae_att(self.query, self.key, self.value, None)
+        
+        self.assertTrue(torch.allclose(moae_output, expert_direct_output, atol=1e-6))
+
+    # 8. Configuration Flexibility & Edge Case Tests
+    def test_moae_seq_len_1(self):
+        query_s1 = torch.randn(self.batch_size, 1, self.d_model, device=self.device)
+        key_s1 = torch.randn(self.batch_size, 1, self.d_model, device=self.device)
+        value_s1 = torch.randn(self.batch_size, 1, self.d_model, device=self.device)
+        
+        moae_att = self.moae_dummy_instance # Uses standard sample configs
+        context = moae_att(query_s1, key_s1, value_s1, None)
+        self.assertEqual(context.shape, (self.batch_size, 1, self.d_model))
+
+    def test_moae_different_num_experts(self):
+        expert_configs_3 = self.sample_expert_configs + [{"type": "local_window_mha", "n_heads": 2, "window_size": 7, "dropout_rate": 0.0}]
+        # Gating config needs to be aware of num_experts, but SoftGateMLP in MOAEAttention init calculates it
+        moae_att = MOAEAttention(self.d_model, expert_configs_3, self.sample_gating_config, 0.0).to(self.device)
+        
+        self.assertEqual(len(moae_att.experts), 3)
+        context = moae_att(self.query, self.key, self.value, None)
+        self.assertEqual(context.shape, (self.batch_size, self.seq_len, self.d_model))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/my_attention_research_project/tests/models/attention/test_pas_attention.py
+++ b/my_attention_research_project/tests/models/attention/test_pas_attention.py
@@ -1,0 +1,183 @@
+import unittest
+import torch
+from my_attention_research_project.models.attention.pas_attention import PASAttention
+
+class TestPASAttention(unittest.TestCase):
+    def setUp(self):
+        self.batch_size = 2
+        self.seq_len_q = 10
+        self.seq_len_k = 12  # Key length can be different
+        self.d_model = 32
+        self.top_k_hotspots = 4
+        self.num_heads_focused = 4
+
+        self.scanner_config_linear = {
+            "type": "PAS_P1_linear",
+            "top_k_hotspots": self.top_k_hotspots
+        }
+        self.focused_attention_config_mha = {
+            "num_heads": self.num_heads_focused,
+            "dropout_rate": 0.0 # No dropout in tests
+        }
+        
+        self.pas_attention_default = PASAttention(
+            d_model=self.d_model,
+            scanner_config=self.scanner_config_linear,
+            focused_attention_config=self.focused_attention_config_mha,
+            dropout_rate=0.0 
+        )
+
+        self.query = torch.rand(self.batch_size, self.seq_len_q, self.d_model)
+        self.key = torch.rand(self.batch_size, self.seq_len_k, self.d_model)
+        self.value = torch.rand(self.batch_size, self.seq_len_k, self.d_model)
+
+    def test_pas_attention_initialization(self):
+        self.assertIsNotNone(self.pas_attention_default)
+        self.assertTrue(callable(self.pas_attention_default.scanner)) # Check if scanner method is assigned
+        self.assertIsNotNone(self.pas_attention_default.focused_attention_mha)
+        if self.pas_attention_default.scanner_config.get("type") == "PAS_P1_linear":
+            self.assertEqual(self.pas_attention_default.top_k_hotspots, self.top_k_hotspots)
+
+    # 2. Test PAS-P1 Linear Scanner
+    def test_linear_scanner_output_shape_and_values(self):
+        pas_attention = self.pas_attention_default
+        
+        # Call scanner directly (it's assigned to self.scanner in __init__)
+        # Ensure scanner is actually configured before calling
+        if not callable(pas_attention.scanner):
+            self.skipTest("Scanner not configured for this PASAttention instance.")
+
+        scanner_output_indices = pas_attention.scanner(self.query, self.key, None)
+        
+        self.assertEqual(scanner_output_indices.shape, 
+                         (self.batch_size, self.seq_len_q, self.top_k_hotspots))
+        
+        self.assertTrue(torch.all(scanner_output_indices >= 0))
+        self.assertTrue(torch.all(scanner_output_indices < self.seq_len_k))
+
+    def test_linear_scanner_padding_masking(self):
+        pas_attention = self.pas_attention_default
+        if not callable(pas_attention.scanner):
+            self.skipTest("Scanner not configured for this PASAttention instance.")
+
+        key_padding_mask = torch.ones(self.batch_size, self.seq_len_k, dtype=torch.bool)
+        num_padded_keys = 2
+        padded_indices_start = self.seq_len_k - num_padded_keys
+        key_padding_mask[:, padded_indices_start:] = False 
+        
+        hotspot_indices = pas_attention.scanner(self.query, self.key, key_padding_mask)
+        
+        # Handle case where top_k_hotspots might be 0
+        if self.top_k_hotspots == 0:
+            self.assertEqual(hotspot_indices.shape[-1], 0)
+            return # No indices to check
+
+        for b in range(self.batch_size):
+            for q_idx in range(self.seq_len_q):
+                for k_idx_pos in range(hotspot_indices.shape[2]): # Iterate up to actual number of hotspots returned
+                    selected_key_index = hotspot_indices[b, q_idx, k_idx_pos].item()
+                    is_padded = not key_padding_mask[b, selected_key_index].item()
+                    self.assertFalse(is_padded, 
+                                     f"Hotspot index {selected_key_index} at batch {b}, query_pos {q_idx} "
+                                     f"points to a padded key. Padded region starts at {padded_indices_start}.")
+    
+    # 3. Test Focused Sparse Attention
+    def test_focused_attention_output_shape(self):
+        pas_attention = self.pas_attention_default
+        if not callable(pas_attention.focused_attention):
+             self.skipTest("Focused attention not configured for this PASAttention instance.")
+
+        dummy_hotspot_indices = torch.randint(0, self.seq_len_k, 
+                                              (self.batch_size, self.seq_len_q, self.top_k_hotspots),
+                                              dtype=torch.long)
+        if self.top_k_hotspots == 0: # If top_k is 0, dummy_hotspot_indices will have last dim 0
+            dummy_hotspot_indices = torch.empty((self.batch_size, self.seq_len_q, 0), dtype=torch.long)
+
+
+        context = pas_attention.focused_attention(self.query, self.key, self.value, 
+                                                  dummy_hotspot_indices, None)
+        
+        self.assertEqual(context.shape, (self.batch_size, self.seq_len_q, self.d_model))
+
+    def test_focused_attention_masking_gathered_keys(self):
+        pas_attention = self.pas_attention_default
+        if not callable(pas_attention.focused_attention):
+            self.skipTest("Focused attention not configured for this PASAttention instance.")
+        if self.top_k_hotspots < 2: # This test assumes at least 2 hotspots can be selected
+            self.skipTest("top_k_hotspots is less than 2, skipping this specific masking test.")
+
+
+        hotspot_indices = torch.zeros(self.batch_size, self.seq_len_q, self.top_k_hotspots, dtype=torch.long)
+        
+        padded_key_original_index = self.seq_len_k - 1
+        hotspot_indices[0, 0, 0] = 0 
+        hotspot_indices[0, 0, 1] = padded_key_original_index 
+        if self.top_k_hotspots > 1: # ensure other hotspots are valid if they exist
+            hotspot_indices[:, :, 2:] = 1 
+
+
+        original_key_padding_mask = torch.ones(self.batch_size, self.seq_len_k, dtype=torch.bool)
+        original_key_padding_mask[:, padded_key_original_index] = False
+
+        distinct_value_marker = torch.ones(self.d_model) * 5.0 
+        value_for_test = torch.zeros_like(self.value)
+        value_for_test[:, padded_key_original_index, :] = distinct_value_marker
+        
+        non_padded_key_original_index = 0
+        non_padded_value_marker = torch.ones(self.d_model) * 1.0
+        value_for_test[:, non_padded_key_original_index, :] = non_padded_value_marker
+
+        context = pas_attention.focused_attention(self.query, self.key, value_for_test, 
+                                                  hotspot_indices, original_key_padding_mask)
+        
+        output_for_q00 = context[0, 0, :]
+
+        similarity_to_padded_value = torch.cosine_similarity(output_for_q00, distinct_value_marker, dim=0)
+        
+        # If output_for_q00 is all zeros (e.g. if all attended keys ended up being masked, or d_model is 1 and value is 0)
+        # then cosine similarity can be nan or 0. We should check this case.
+        is_output_zero = torch.allclose(output_for_q00, torch.zeros_like(output_for_q00), atol=1e-6)
+
+        self.assertTrue(is_output_zero or similarity_to_padded_value < 0.5, 
+                        f"Output context for query[0,0] seems to reflect contribution from the padded key. "
+                        f"Similarity to padded value: {similarity_to_padded_value.item()}. Output sum: {output_for_q00.sum().item()}")
+
+    # 4. Test PASAttention End-to-End
+    def test_pas_attention_e2e_run(self):
+        pas_attention = self.pas_attention_default
+        
+        # PASAttention.forward returns: context_vector, hotspot_indices
+        context, hotspot_indices_output = pas_attention(self.query, self.key, self.value, None)
+        
+        self.assertEqual(context.shape, (self.batch_size, self.seq_len_q, self.d_model))
+        self.assertIsNotNone(hotspot_indices_output)
+        self.assertEqual(hotspot_indices_output.shape, 
+                         (self.batch_size, self.seq_len_q, self.top_k_hotspots))
+
+    def test_pas_attention_e2e_with_padding(self):
+        pas_attention = self.pas_attention_default
+        
+        input_padding_mask = torch.ones(self.batch_size, self.seq_len_k, dtype=torch.bool)
+        num_padded_keys = 3
+        padded_indices_start = self.seq_len_k - num_padded_keys
+        input_padding_mask[:, padded_indices_start:] = False
+        
+        context, hotspot_indices_output = pas_attention(self.query, self.key, self.value, input_padding_mask)
+        
+        self.assertEqual(context.shape, (self.batch_size, self.seq_len_q, self.d_model))
+        self.assertIsNotNone(hotspot_indices_output)
+        self.assertEqual(hotspot_indices_output.shape, 
+                         (self.batch_size, self.seq_len_q, self.top_k_hotspots))
+        
+        if self.top_k_hotspots > 0 and hotspot_indices_output.shape[2] > 0 : # if any hotspots were actually returned
+            for b in range(self.batch_size):
+                for q_idx in range(self.seq_len_q):
+                    for k_idx_pos in range(hotspot_indices_output.shape[2]):
+                        selected_key_index = hotspot_indices_output[b, q_idx, k_idx_pos].item()
+                        is_padded = not input_padding_mask[b, selected_key_index].item()
+                        self.assertFalse(is_padded,
+                                         f"E2E: Hotspot index {selected_key_index} at batch {b}, query_pos {q_idx} "
+                                         f"points to a padded key. Padded region starts at {padded_indices_start}.")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/my_attention_research_project/training/experiment_runner.py
+++ b/my_attention_research_project/training/experiment_runner.py
@@ -4,10 +4,10 @@ import random
 import numpy as np
 import logging
 from pathlib import Path
+import os # Added
+import pandas as pd # Added
 
 # Project-specific imports
-# Assuming this script is run as a module from the project root, e.g.,
-# python -m my_attention_research_project.training.experiment_runner --config ...
 try:
     from ..utils.config_parser import load_config
     from ..data.tokenizer import load_tokenizer
@@ -15,20 +15,17 @@ try:
     from ..models.transformer import TransformerEncoder
     from .train_loop import Trainer
 except ImportError as e:
-    # Allow running script directly for development/testing if paths are adjusted or project is in PYTHONPATH
     print(f"ImportError: {e}. This might be due to running the script directly without the project package being installed or in PYTHONPATH.")
     print("Attempting to proceed. If project-specific imports fail, ensure you run as a module or adjust PYTHONPATH.")
-    # Re-raise if it's not a direct run (__name__ != '__main__') because then it's a structural problem.
     if __name__ != '__main__':
         raise
-    # For direct run, these imports might fail if the relative paths don't resolve.
-    # This block is more for awareness during development.
-    # A robust solution for direct script running might involve temporarily adding project root to sys.path.
-
 
 # Logger Setup
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+# Ensure basicConfig is called only if no handlers are already configured
+if not logger.hasHandlers():
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
 
 def set_seed(seed_value):
     """Sets the seed for reproducibility."""
@@ -37,57 +34,45 @@ def set_seed(seed_value):
     torch.manual_seed(seed_value)
     if torch.cuda.is_available():
         torch.cuda.manual_seed_all(seed_value)
-        # Optional: for full determinism, might impact performance
         torch.backends.cudnn.deterministic = True 
         torch.backends.cudnn.benchmark = False   
     logger.info(f"Set random seed to {seed_value}")
 
-def main():
+def main(): # This function serves as run_experiment
     parser = argparse.ArgumentParser(description="Experiment Runner for Transformer Models")
     parser.add_argument('--config', type=str, required=True, help="Path to the YAML configuration file.")
     args = parser.parse_args()
+    config_path = args.config # Store config path for logging
 
-    # Load Configuration
-    logger.info(f"Loading configuration from: {args.config}")
-    config = load_config(args.config)
+    logger.info(f"Loading configuration from: {config_path}")
+    config = load_config(config_path)
     if not config:
         logger.error("Configuration file could not be loaded. Exiting.")
         return
 
-    # Set Seed
     seed = config.get('training', {}).get('random_seed', 42)
     set_seed(seed)
 
-    # Device Setup
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     logger.info(f"Using device: {device}")
 
-    # Tokenizer Initialization
     tokenizer_name_or_path = config.get('data', {}).get('tokenizer_name_or_path', 'gpt2')
-    tokenizer_max_len = config.get('data', {}).get('tokenizer_max_length', 1024) # Used by preprocess & load_tokenizer for context
+    tokenizer_max_len = config.get('data', {}).get('tokenizer_max_length', 1024)
     
     logger.info(f"Loading tokenizer: {tokenizer_name_or_path}")
     tokenizer = load_tokenizer(tokenizer_name_or_path, max_length=tokenizer_max_len)
     
     pad_token_id = tokenizer.pad_token_id
     if pad_token_id is None:
-        # load_tokenizer should set pad_token = eos_token if pad is missing (e.g. for GPT2)
-        # So, pad_token_id should then be tokenizer.eos_token_id
-        # If both are None, it's an issue.
         if tokenizer.eos_token_id is not None:
             pad_token_id = tokenizer.eos_token_id
-            logger.warning(f"Tokenizer's pad_token_id is None. Using eos_token_id ({pad_token_id}) as pad_token_id for CausalLMTrainingDataset.")
+            logger.warning(f"Tokenizer's pad_token_id is None. Using eos_token_id ({pad_token_id}) as pad_token_id.")
         else:
-            # This should ideally not happen with standard Hugging Face tokenizers
-            logger.error("Tokenizer does not have a pad_token_id or eos_token_id. Cannot proceed.")
-            # Defaulting to 0, but this is risky and dataset/model might behave unexpectedly.
             pad_token_id = 0 
-            logger.warning("Setting pad_token_id to 0 as a fallback. This is not recommended.")
+            logger.warning("Tokenizer does not have pad_token_id or eos_token_id. Setting pad_token_id to 0.")
 
-    # Data Preparation
-    # Using experiment-specific subdirectories for raw and processed data
     experiment_data_base_dir = config.get('data', {}).get('experiment_data_base_dir', './data/experiment_run_data')
-    run_name = config.get('experiment_name', Path(args.config).stem) # Use config name as default run_name
+    run_name = config.get('experiment_name', Path(config_path).stem) 
     
     raw_data_dir = Path(experiment_data_base_dir) / run_name / 'raw'
     processed_data_dir = Path(experiment_data_base_dir) / run_name / 'processed'
@@ -95,21 +80,17 @@ def main():
     logger.info(f"Raw data directory: {raw_data_dir}")
     logger.info(f"Processed data directory: {processed_data_dir}")
 
-    # Ensure directories exist
     raw_data_dir.mkdir(parents=True, exist_ok=True)
     processed_data_dir.mkdir(parents=True, exist_ok=True)
 
     logger.info("Downloading/creating raw text files...")
-    download_raw_text_files(str(raw_data_dir)) # Creates dummy train.txt, valid.txt, test.txt
+    download_raw_text_files(str(raw_data_dir))
 
     logger.info("Preprocessing text files for Causal LM...")
-    # Pass the tokenizer_name_or_path, not the instance, as preprocess_text_files_for_causal_lm re-loads it.
     preprocess_text_files_for_causal_lm(str(raw_data_dir), str(processed_data_dir), tokenizer_name_or_path, config)
 
     train_file = processed_data_dir / "train.jsonl"
     valid_file = processed_data_dir / "valid.jsonl"
-    # test_file = processed_data_dir / "test.jsonl" # For future use
-
     sequence_length = config.get('data', {}).get('sequence_length', 256)
     
     logger.info(f"Loading training dataset from: {train_file}")
@@ -120,67 +101,87 @@ def main():
     valid_dataset = CausalLMTrainingDataset(str(valid_file), sequence_length, pad_token_id)
     logger.info(f"Validation dataset size: {len(valid_dataset)} examples")
 
-    # Model Initialization
     model_config = config.get('model', {})
-    vocab_size = tokenizer.vocab_size # Use actual vocab size from the loaded tokenizer
+    vocab_size = tokenizer.vocab_size
     logger.info(f"Initializing model (TransformerEncoder) with vocab_size: {vocab_size}")
 
-    # Extract attention-specific configuration from the model_config
     attention_specific_config = model_config.get('attention')
     if not attention_specific_config:
-        logger.error("Key 'attention' missing in model configuration ('model.attention'). Cannot initialize TransformerEncoder.")
-        return # Or raise a more specific error
+        logger.error("Key 'attention' missing in model configuration. Cannot initialize TransformerEncoder.")
+        return
 
-    # TODO: Add logic to select model type based on config['model']['type'] if more models are introduced.
-    # For now, directly uses TransformerEncoder.
     model = TransformerEncoder(
         vocab_size=vocab_size,
         d_model=model_config.get('d_model', 256),
-        attention_config=attention_specific_config, # Pass the extracted attention configuration
+        attention_config=attention_specific_config,
         num_encoder_layers=model_config.get('num_encoder_layers', 3),
         ffn_dim_factor=model_config.get('ffn_dim_factor', 4),
         dropout_rate=model_config.get('dropout_rate', 0.1),
         use_positional_embeddings=model_config.get('use_positional_embeddings', True),
         pos_encoding_max_len=model_config.get('pos_encoding_max_len', 5000),
         embedding_scale_factor=model_config.get('embedding_scale_factor', None) 
-        # embedding_scale_grad_by_freq is False by default in TransformerEncoder
     )
     model.to(device)
 
     num_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
     logger.info(f"Model initialized. Total trainable parameters: {num_params/1e6:.2f}M")
 
-    # Trainer Initialization
     logger.info("Initializing Trainer...")
-    # The config passed to Trainer should ideally be the full config dict for flexibility
     trainer = Trainer(config, model, train_dataset, valid_dataset)
 
-    # Start Training
     logger.info("Starting training...")
+    all_epoch_summaries = [] # Initialize in case training fails early
     try:
-        trainer.train()
+        all_epoch_summaries = trainer.train() # Capture the returned list of metrics
     except Exception as e:
         logger.error(f"An error occurred during training: {e}", exc_info=True)
     finally:
         logger.info("Training finished or an error occurred.")
-        # Optional: cleanup experiment data directories if they were temporary
-        # cleanup_data = config.get('training', {}).get('cleanup_experiment_data_on_finish', False)
-        # if cleanup_data:
-        #     logger.info(f"Cleaning up experiment data directory: {Path(experiment_data_base_dir) / run_name}")
-        #     shutil.rmtree(Path(experiment_data_base_dir) / run_name)
+        
+        if all_epoch_summaries:
+            df_metrics = pd.DataFrame(all_epoch_summaries)
+            
+            # Add configuration parameters
+            df_metrics['config_file'] = Path(config_path).name # Log only filename for brevity
+            
+            # Safely access nested config values
+            cfg_model = config.get('model', {})
+            cfg_model_attention = cfg_model.get('attention', {})
+            cfg_data = config.get('data', {})
+
+            df_metrics['attention_type'] = cfg_model_attention.get('type', 'N/A')
+            df_metrics['d_model'] = cfg_model.get('d_model', 'N/A')
+            df_metrics['num_encoder_layers'] = cfg_model.get('num_encoder_layers', 'N/A')
+            df_metrics['sequence_length'] = cfg_data.get('sequence_length', 'N/A')
+
+            attention_type = cfg_model_attention.get('type')
+            if attention_type == "AHC":
+                df_metrics['ahc_chunk_size'] = cfg_model_attention.get('chunk_size', 'N/A')
+            elif attention_type == "PAS":
+                scanner_cfg = cfg_model_attention.get('scanner_config', {})
+                df_metrics['pas_top_k_hotspots'] = scanner_cfg.get('top_k_hotspots', 'N/A')
+            elif attention_type == "MOAE":
+                expert_cfgs = cfg_model_attention.get('expert_configs', [])
+                df_metrics['moae_num_experts'] = len(expert_cfgs) if isinstance(expert_cfgs, list) else 'N/A'
+            
+            # Define CSV output path
+            output_dir = Path(config.get('training', {}).get('results_dir', './experiment_results/'))
+            output_dir.mkdir(parents=True, exist_ok=True)
+            csv_output_path = output_dir / "benchmark_results.csv"
+
+            # Save to CSV
+            try:
+                if os.path.exists(csv_output_path):
+                    df_metrics.to_csv(csv_output_path, mode='a', header=False, index=False)
+                    logger.info(f"Appended benchmark results to {csv_output_path}")
+                else:
+                    df_metrics.to_csv(csv_output_path, mode='w', header=True, index=False)
+                    logger.info(f"Saved new benchmark results to {csv_output_path}")
+            except Exception as e_csv:
+                logger.error(f"Error saving results to CSV {csv_output_path}: {e_csv}", exc_info=True)
+        else:
+            logger.warning("No epoch summaries were collected. Skipping CSV logging.")
 
 
 if __name__ == '__main__':
-    # To run this script:
-    # 1. Ensure your project root is in PYTHONPATH or you are in the project root.
-    # 2. Execute as a module:
-    #    python -m my_attention_research_project.training.experiment_runner --config my_attention_research_project/configs/base_mha_config.yaml
-    #    (Adjust path to config as needed)
-    #
-    # If running directly for quick tests and imports fail, you might need to adjust sys.path:
-    # import sys
-    # sys.path.insert(0, str(Path(__file__).resolve().parents[2])) # Add project root to path
-    # from my_attention_research_project.utils.config_parser import load_config
-    # ... etc.
-    # However, running as a module is preferred.
     main()

--- a/my_attention_research_project/training/train_loop.py
+++ b/my_attention_research_project/training/train_loop.py
@@ -4,40 +4,31 @@
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader, Dataset
-import time
+import time # Ensure time is imported
 import yaml # For config type hinting if used, or general dict
 from pathlib import Path
 import logging # For logging
 import shutil # For __main__ example cleanup
 
 # For type hinting if needed, or __main__ example.
-# Ensure this path is correct based on your project structure.
-# If train_loop.py is run directly, this might cause issues if not handled by try-except or if __main__ is complex.
 try:
     from ..models.transformer import TransformerEncoder 
 except ImportError:
-    # This allows the script to run for the __main__ example even if models aren't perfectly on PYTHONPATH
-    # when run directly, assuming DummyModel is self-contained for the example.
-    if __name__ != '__main__': # Re-raise if not in main, as it's a real import error for library use
+    if __name__ != '__main__': 
         raise
     print("Warning: Could not import TransformerEncoder. This is fine if running the __main__ example with DummyModel.")
-    TransformerEncoder = None # Define it as None for type hinting if import fails
+    TransformerEncoder = None 
 
-# Basic logger setup
-logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__) # Use module-level logger
+# BasicConfig should ideally be called once at application entry point.
+# If this script is run standalone, it's fine. If imported, it might conflict or have no effect if already configured.
+# For this project, assuming it's called early enough or this is the main config point for logging.
+if not logger.hasHandlers(): # Avoid adding multiple handlers if imported multiple times or run after setup
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
 
 class Trainer:
     def __init__(self, config: dict, model: nn.Module, train_dataset: Dataset, valid_dataset: Dataset = None):
-        """
-        Initializes the Trainer.
-
-        Args:
-            config (dict): Configuration dictionary.
-            model (nn.Module): The PyTorch model to train.
-            train_dataset (Dataset): Training dataset.
-            valid_dataset (Dataset, optional): Validation dataset. Defaults to None.
-        """
         logger.info("Initializing Trainer...")
         self.config = config
         self.model = model
@@ -48,7 +39,6 @@ class Trainer:
         logger.info(f"Using device: {self.device}")
         self.model.to(self.device)
 
-        # Optimizer
         optimizer_name = self.config.get('training', {}).get('optimizer', 'AdamW')
         lr = float(self.config.get('training', {}).get('learning_rate', 1e-4))
         weight_decay = float(self.config.get('training', {}).get('weight_decay', 0.01))
@@ -62,31 +52,21 @@ class Trainer:
             self.optimizer = torch.optim.AdamW(self.model.parameters(), lr=lr, weight_decay=weight_decay)
         
         logger.info(f"Optimizer: {optimizer_name}, LR: {lr}, Weight Decay: {weight_decay}")
-
-        # Loss Function (CrossEntropyLoss for Language Modeling, ignoring -100 for labels)
         self.criterion = nn.CrossEntropyLoss(ignore_index=-100)
 
-        # DataLoaders
         batch_size = self.config.get('data', {}).get('batch_size', 32)
-        num_workers = self.config.get('data', {}).get('num_workers', 0) # Default to 0 for simpler setups
+        num_workers = self.config.get('data', {}).get('num_workers', 0)
         pin_memory = self.config.get('data', {}).get('pin_memory', True if self.device.type == 'cuda' else False)
 
         self.train_loader = DataLoader(
-            self.train_dataset, 
-            batch_size=batch_size, 
-            shuffle=True, 
-            num_workers=num_workers, 
-            pin_memory=pin_memory
-        )
+            self.train_dataset, batch_size=batch_size, shuffle=True, 
+            num_workers=num_workers, pin_memory=pin_memory)
+        
         if self.valid_dataset:
             eval_batch_size = self.config.get('benchmarking', {}).get('batch_size_inference', batch_size)
             self.valid_loader = DataLoader(
-                self.valid_dataset, 
-                batch_size=eval_batch_size, 
-                shuffle=False, 
-                num_workers=num_workers, 
-                pin_memory=pin_memory
-            )
+                self.valid_dataset, batch_size=eval_batch_size, shuffle=False, 
+                num_workers=num_workers, pin_memory=pin_memory)
         else:
             self.valid_loader = None
             
@@ -94,7 +74,6 @@ class Trainer:
         if self.valid_loader:
              logger.info(f"Valid DataLoader: batch_size={eval_batch_size}, num_examples={len(self.valid_dataset)}, num_workers={num_workers}")
 
-        # LR Scheduler
         self.lr_scheduler = None
         scheduler_config = self.config.get('training', {}).get('lr_scheduler', {})
         if scheduler_config and scheduler_config.get('type'):
@@ -104,21 +83,13 @@ class Trainer:
                 total_steps = num_epochs * len(self.train_loader)
                 eta_min = float(scheduler_config.get('min_lr', 0.0))
                 self.lr_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
-                    self.optimizer, 
-                    T_max=total_steps,
-                    eta_min=eta_min
-                )
+                    self.optimizer, T_max=total_steps, eta_min=eta_min)
                 logger.info(f"Using CosineAnnealingLR scheduler. T_max={total_steps}, eta_min={eta_min}")
-            elif scheduler_type == 'linear_warmup_decay':
-                # Placeholder - requires more parameters like warmup_steps
-                logger.warning("LinearWarmupDecay scheduler placeholder - not implemented yet.")
             elif scheduler_type == 'reduce_lr_on_plateau':
                 self.lr_scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-                    self.optimizer,
-                    mode=scheduler_config.get('mode', 'min'),
+                    self.optimizer, mode=scheduler_config.get('mode', 'min'),
                     factor=float(scheduler_config.get('factor', 0.1)),
-                    patience=int(scheduler_config.get('patience', 10)),
-                )
+                    patience=int(scheduler_config.get('patience', 10)))
                 logger.info(f"Using ReduceLROnPlateau scheduler.")
             else:
                 logger.info(f"LR scheduler type '{scheduler_type}' not recognized or no LR scheduler configured.")
@@ -133,28 +104,40 @@ class Trainer:
         self.best_val_loss = float('inf')
         self.best_val_perplexity = float('inf')
 
+    def log_memory_usage(self, context_message: str = ""):
+        """Logs current and peak GPU memory usage if CUDA is available."""
+        peak_gpu_memory_mb = 0
+        if self.device.type == 'cuda':
+            # current_memory_mb = torch.cuda.memory_allocated(self.device) / (1024 * 1024)
+            peak_memory_mb = torch.cuda.max_memory_allocated(self.device) / (1024 * 1024)
+            # logger.info(f"Current GPU Memory usage {context_message}: {current_memory_mb:.2f} MB")
+            logger.info(f"Peak GPU Memory Allocated {context_message}: {peak_memory_mb:.2f} MB")
+            # Reset peak stats for the next measurement period if desired (e.g., per epoch)
+            # torch.cuda.reset_peak_memory_stats(self.device) # Be careful with this
+        else:
+            logger.info(f"Memory usage logging: CUDA not available. {context_message}")
+        return peak_gpu_memory_mb
 
-    def _train_one_epoch(self):
+
+    def _train_one_epoch(self) -> dict:
         self.model.train()
         total_loss = 0
         num_batches = len(self.train_loader)
         
         logger.info(f"Starting Training Epoch {self.current_epoch + 1}")
         epoch_start_time = time.time()
+        total_tokens_in_epoch = 0
 
         for batch_idx, batch_data in enumerate(self.train_loader):
             input_ids = batch_data["input_ids"].to(self.device)
             attention_mask = batch_data["attention_mask"].to(self.device)
             labels = batch_data["labels"].to(self.device)
             
+            total_tokens_in_epoch += input_ids.numel() # input_ids.size(0) * input_ids.size(1)
+            
             self.optimizer.zero_grad()
-            
             logits = self.model(input_ids=input_ids, attention_mask=attention_mask)
-            # logits shape: (batch_size, seq_len, vocab_size)
-            # labels shape: (batch_size, seq_len)
-            
             loss = self.criterion(logits.view(-1, logits.size(-1)), labels.view(-1))
-            
             loss.backward()
             
             if self.gradient_clipping_norm:
@@ -162,33 +145,42 @@ class Trainer:
             
             self.optimizer.step()
             
-            # Step LR scheduler if it's per-step (e.g., CosineAnnealingLR)
             scheduler_config = self.config.get('training', {}).get('lr_scheduler', {})
             if self.lr_scheduler and scheduler_config.get('update_frequency', 'epoch') == 'step':
-                if not isinstance(self.lr_scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau): # ReduceLROnPlateau steps per epoch
+                if not isinstance(self.lr_scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau):
                     self.lr_scheduler.step()
 
             total_loss += loss.item()
             
-            if (batch_idx + 1) % (num_batches // 10 if num_batches > 10 else 1) == 0: # Log ~10 times per epoch
+            if (batch_idx + 1) % (num_batches // 10 if num_batches > 10 else 1) == 0:
                 logger.info(f"  Epoch {self.current_epoch + 1}, Batch {batch_idx + 1}/{num_batches}, Loss: {loss.item():.4f}")
 
         avg_epoch_loss = total_loss / num_batches
         epoch_duration = time.time() - epoch_start_time
+        training_tokens_per_sec = total_tokens_in_epoch / epoch_duration if epoch_duration > 0 else 0
+        
         logger.info(f"Finished Training Epoch {self.current_epoch + 1}. Average Loss: {avg_epoch_loss:.4f}. Duration: {epoch_duration:.2f}s")
-        return avg_epoch_loss
+        logger.info(f"Training throughput: {training_tokens_per_sec:.2f} tokens/sec")
+        
+        epoch_metrics = {
+            'epoch_train_loss': avg_epoch_loss,
+            'training_tokens_per_sec': training_tokens_per_sec,
+            'epoch_lr': self.optimizer.param_groups[0]['lr'] # Get current LR
+        }
+        return epoch_metrics
 
-    def _validate_one_epoch(self):
+    def _validate_one_epoch(self) -> dict:
         if not self.valid_loader:
             logger.info("No validation loader provided. Skipping validation.")
-            return None, None
+            return {'perplexity': None, 'eval_loss': None, 'inference_tokens_per_sec': None}
 
         self.model.eval()
         total_val_loss = 0
         num_batches = len(self.valid_loader)
         
         logger.info(f"Starting Validation for Epoch {self.current_epoch + 1}")
-        epoch_start_time = time.time()
+        eval_start_time = time.time()
+        total_tokens_in_eval = 0
 
         with torch.no_grad():
             for batch_idx, batch_data in enumerate(self.valid_loader):
@@ -196,48 +188,88 @@ class Trainer:
                 attention_mask = batch_data["attention_mask"].to(self.device)
                 labels = batch_data["labels"].to(self.device)
                 
+                total_tokens_in_eval += input_ids.numel()
+                
                 logits = self.model(input_ids=input_ids, attention_mask=attention_mask)
                 loss = self.criterion(logits.view(-1, logits.size(-1)), labels.view(-1))
                 total_val_loss += loss.item()
                 
         avg_val_loss = total_val_loss / num_batches
-        perplexity = torch.exp(torch.tensor(avg_val_loss)) # Calculate perplexity from average loss
+        perplexity = torch.exp(torch.tensor(avg_val_loss)).item() 
         
-        epoch_duration = time.time() - epoch_start_time
-        logger.info(f"Finished Validation for Epoch {self.current_epoch + 1}. Average Loss: {avg_val_loss:.4f}, Perplexity: {perplexity:.2f}. Duration: {epoch_duration:.2f}s")
+        eval_duration = time.time() - eval_start_time
+        inference_tokens_per_sec = total_tokens_in_eval / eval_duration if eval_duration > 0 else 0
         
-        return avg_val_loss, perplexity
+        logger.info(f"Finished Validation for Epoch {self.current_epoch + 1}. Average Loss: {avg_val_loss:.4f}, Perplexity: {perplexity:.2f}. Duration: {eval_duration:.2f}s")
+        logger.info(f"Inference throughput: {inference_tokens_per_sec:.2f} tokens/sec")
+        
+        eval_metrics = {
+            'perplexity': perplexity,
+            'eval_loss': avg_val_loss,
+            'inference_tokens_per_sec': inference_tokens_per_sec
+        }
+        return eval_metrics
 
     def train(self):
         num_epochs = self.config.get('training', {}).get('num_epochs', 10)
         logger.info(f"Starting training for {num_epochs} epochs.")
+        
+        all_epoch_summaries = [] # To store metrics from all epochs
 
-        for epoch in range(self.current_epoch, num_epochs): # Resume from self.current_epoch
+        for epoch in range(self.current_epoch, num_epochs):
             self.current_epoch = epoch
             
-            train_loss = self._train_one_epoch()
-            val_loss, val_perplexity = self._validate_one_epoch()
+            # Reset peak memory stats at the beginning of each epoch measurement cycle
+            if self.device.type == 'cuda':
+                torch.cuda.reset_peak_memory_stats(self.device)
             
-            # Step LR scheduler if it's per-epoch
+            train_metrics = self._train_one_epoch()
+            peak_gpu_memory_after_train_mb = self.log_memory_usage(f"after Training Epoch {self.current_epoch + 1}")
+            
+            eval_metrics = self._validate_one_epoch()
+            peak_gpu_memory_after_eval_mb = self.log_memory_usage(f"after Validation Epoch {self.current_epoch + 1}")
+            
+            # Use the higher of the two peaks for the epoch summary
+            epoch_peak_gpu_memory_mb = max(peak_gpu_memory_after_train_mb, peak_gpu_memory_after_eval_mb)
+
             scheduler_config = self.config.get('training', {}).get('lr_scheduler', {})
             if self.lr_scheduler and scheduler_config.get('update_frequency', 'epoch') == 'epoch':
                 if isinstance(self.lr_scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau):
-                    self.lr_scheduler.step(val_loss if val_loss is not None else float('inf'))
+                    self.lr_scheduler.step(eval_metrics['eval_loss'] if eval_metrics['eval_loss'] is not None else float('inf'))
                 else:
                     self.lr_scheduler.step()
             
-            current_lr = self.optimizer.param_groups[0]['lr']
-            logger.info(f"End of Epoch {self.current_epoch + 1}. Current LR: {current_lr:.6e}")
+            current_lr = self.optimizer.param_groups[0]['lr'] # Already in train_metrics, but good to have for summary
+            
+            epoch_summary_metrics = {
+                'epoch': self.current_epoch + 1,
+                'learning_rate': current_lr,
+                'training_loss': train_metrics['epoch_train_loss'],
+                'validation_loss': eval_metrics['eval_loss'],
+                'perplexity': eval_metrics['perplexity'],
+                'training_tokens_per_sec': train_metrics['training_tokens_per_sec'],
+                'inference_tokens_per_sec': eval_metrics['inference_tokens_per_sec'],
+                'peak_gpu_memory_mb': epoch_peak_gpu_memory_mb
+            }
+            all_epoch_summaries.append(epoch_summary_metrics) # Store for later use
 
-            if val_loss is not None and val_loss < self.best_val_loss:
-                self.best_val_loss = val_loss
-                self.best_val_perplexity = val_perplexity if val_perplexity is not None else self.best_val_perplexity
+            logger.info(f"Epoch {epoch_summary_metrics['epoch']} Summary: LR={epoch_summary_metrics['learning_rate']:.6e}, "
+                        f"Train Loss={epoch_summary_metrics['training_loss']:.4f}, Valid Loss={epoch_summary_metrics['validation_loss']:.4f}, "
+                        f"Perplexity={epoch_summary_metrics['perplexity']:.2f}, Train Tok/s={epoch_summary_metrics['training_tokens_per_sec']:.0f}, "
+                        f"Eval Tok/s={epoch_summary_metrics['inference_tokens_per_sec']:.0f}, Peak Mem={epoch_summary_metrics['peak_gpu_memory_mb']:.2f}MB")
+
+
+            if eval_metrics['eval_loss'] is not None and eval_metrics['eval_loss'] < self.best_val_loss:
+                self.best_val_loss = eval_metrics['eval_loss']
+                self.best_val_perplexity = eval_metrics['perplexity'] if eval_metrics['perplexity'] is not None else self.best_val_perplexity
                 logger.info(f"New best validation loss: {self.best_val_loss:.4f} (Perplexity: {self.best_val_perplexity:.2f}). Saving model...")
                 self.save_checkpoint(f"checkpoint_epoch_{self.current_epoch+1}_best.pt")
             
         logger.info("Training finished.")
         logger.info(f"Best validation loss: {self.best_val_loss:.4f}, Best validation perplexity: {self.best_val_perplexity:.2f}")
-        return self.best_val_loss, self.best_val_perplexity
+        
+        # This list of dictionaries can be returned or used by a higher-level runner
+        return all_epoch_summaries
 
 
     def save_checkpoint(self, file_name: str = "model_checkpoint.pt"):
@@ -269,7 +301,7 @@ class Trainer:
             checkpoint = torch.load(load_path, map_location=self.device)
             self.model.load_state_dict(checkpoint['model_state_dict'])
             self.optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
-            self.current_epoch = checkpoint.get('epoch', 0) # Default to 0 if not found
+            self.current_epoch = checkpoint.get('epoch', 0) 
             self.best_val_loss = checkpoint.get('best_val_loss', float('inf'))
             self.best_val_perplexity = checkpoint.get('best_val_perplexity', float('inf'))
             
@@ -283,28 +315,23 @@ class Trainer:
 
 
 if __name__ == '__main__':
-    logger.info("Running train_loop.py example...")
+    # Ensure logger is configured for __main__
+    if not logging.getLogger().hasHandlers():
+         logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    main_logger = logging.getLogger(__name__) # Use the module's logger
+
+    main_logger.info("Running train_loop.py example...")
 
     class DummyModel(nn.Module):
-        def __init__(self, vocab_size=100, d_model=32): # Removed seq_len as it's dynamic
+        def __init__(self, vocab_size=100, d_model=32): 
             super().__init__()
             self.embedding = nn.Embedding(vocab_size, d_model)
             self.fc = nn.Linear(d_model, vocab_size) 
-            self.vocab_size = vocab_size # Used for dummy output generation
+            self.vocab_size = vocab_size 
 
-        def forward(self, input_ids, attention_mask=None): # Add attention_mask
-            # input_ids shape: (batch, seq_len)
-            # attention_mask shape: (batch, seq_len) - not used by this dummy model
-            # In a real model, attention_mask would be used by attention layers.
-            
-            # Dummy logic: just use embeddings and project.
-            # This is not a realistic model for sequence processing.
-            embeddings = self.embedding(input_ids) # (batch, seq_len, d_model)
-            # To make it slightly more "realistic" for loss calculation, let's average embeddings
-            # and then project, so output is (batch, vocab_size) if labels are (batch).
-            # However, our Trainer expects (batch, seq_len, vocab_size) for logits.
-            # So, let's just project each token embedding.
-            logits = self.fc(embeddings) # (batch, seq_len, vocab_size)
+        def forward(self, input_ids, attention_mask=None): 
+            embeddings = self.embedding(input_ids) 
+            logits = self.fc(embeddings) 
             return logits
 
     class DummyDataset(Dataset):
@@ -313,36 +340,25 @@ if __name__ == '__main__':
             self.seq_len = seq_len
             self.vocab_size = vocab_size
             self.input_ids_data = torch.randint(0, vocab_size, (num_samples, seq_len))
-            self.labels_data = torch.randint(0, vocab_size, (num_samples, seq_len)) # Dummy labels
-            # For CausalLM, labels are often input_ids shifted, but for this dummy, random is fine.
+            self.labels_data = torch.randint(0, vocab_size, (num_samples, seq_len)) 
+            self.attention_mask_data = torch.ones_like(self.input_ids_data)
 
         def __len__(self):
             return self.num_samples
 
         def __getitem__(self, idx):
-            input_ids_chunk = self.input_ids_data[idx]
-            labels_chunk = self.labels_data[idx]
-            # Create a dummy attention mask (all 1s, meaning all tokens are attended to)
-            attention_mask_chunk = torch.ones_like(input_ids_chunk)
-            return {"input_ids": input_ids_chunk, 
-                    "attention_mask": attention_mask_chunk, 
-                    "labels": labels_chunk}
+            return {"input_ids": self.input_ids_data[idx], 
+                    "attention_mask": self.attention_mask_data[idx], 
+                    "labels": self.labels_data[idx]}
 
     dummy_config_dict = {
         'model': {'vocab_size': 100, 'd_model': 32}, 
         'data': {'batch_size': 8, 'sequence_length': 64, 'num_workers': 0, 'pin_memory': False},
         'training': {
-            'optimizer': 'AdamW',
-            'learning_rate': 1e-3,
-            'weight_decay': 0.01,
-            'num_epochs': 2,
-            'gradient_clipping': 1.0,
-            'checkpoint_dir': './dummy_checkpoints_train_loop_final',
-            'lr_scheduler': {
-                'type': 'cosine_annealing', # Example scheduler
-                'min_lr': 1e-5,
-                'update_frequency': 'step' # Can be 'step' or 'epoch'
-            }
+            'optimizer': 'AdamW', 'learning_rate': 1e-3, 'weight_decay': 0.01,
+            'num_epochs': 2, 'gradient_clipping': 1.0,
+            'checkpoint_dir': './dummy_checkpoints_train_loop_enhanced',
+            'lr_scheduler': {'type': 'cosine_annealing', 'min_lr': 1e-5, 'update_frequency': 'step'}
         },
         'benchmarking': {'batch_size_inference': 8}
     }
@@ -357,41 +373,34 @@ if __name__ == '__main__':
             vocab_size=dummy_config_dict['model']['vocab_size'],
             d_model=dummy_config_dict['model']['d_model']
         )
-        
-        train_ds = DummyDataset(
-            num_samples=128, 
-            seq_len=dummy_config_dict['data']['sequence_length'], 
-            vocab_size=dummy_config_dict['model']['vocab_size']
-        )
-        valid_ds = DummyDataset(
-            num_samples=64, 
-            seq_len=dummy_config_dict['data']['sequence_length'], 
-            vocab_size=dummy_config_dict['model']['vocab_size']
-        )
+        train_ds = DummyDataset(num_samples=128, seq_len=dummy_config_dict['data']['sequence_length'], vocab_size=dummy_config_dict['model']['vocab_size'])
+        valid_ds = DummyDataset(num_samples=64, seq_len=dummy_config_dict['data']['sequence_length'], vocab_size=dummy_config_dict['model']['vocab_size'])
 
         trainer = Trainer(config=dummy_config_dict, model=model, train_dataset=train_ds, valid_dataset=valid_ds)
         
-        logger.info("Starting dummy training...")
-        trainer.train()
-        logger.info("Dummy training finished.")
+        main_logger.info("Starting dummy training with enhanced logging...")
+        epoch_metrics_history = trainer.train() # Capture the history
+        main_logger.info("Dummy training finished.")
+        
+        if epoch_metrics_history:
+            main_logger.info("Metrics history collected:")
+            for epoch_summary in epoch_metrics_history:
+                main_logger.info(f"  Epoch {epoch_summary['epoch']}: {epoch_summary}")
+        else:
+            main_logger.warning("No metrics history was collected.")
 
-        trainer.save_checkpoint("dummy_final.pt")
-        # Create a new trainer instance to test loading
-        model_new = DummyModel(
-            vocab_size=dummy_config_dict['model']['vocab_size'],
-            d_model=dummy_config_dict['model']['d_model']
-        )
+
+        trainer.save_checkpoint("dummy_final_enhanced.pt")
+        model_new = DummyModel(vocab_size=dummy_config_dict['model']['vocab_size'], d_model=dummy_config_dict['model']['d_model'])
         trainer_new = Trainer(config=dummy_config_dict, model=model_new, train_dataset=train_ds, valid_dataset=valid_ds)
-        trainer_new.load_checkpoint(checkpoint_dir_path / "dummy_final.pt")
-        logger.info("Dummy checkpoint save/load test complete. Loaded epoch: %s", trainer_new.current_epoch)
-        # Try one more epoch to ensure scheduler and optimizer states were reloaded correctly
-        # trainer_new.train() # This would require num_epochs in config to be > loaded epoch
+        trainer_new.load_checkpoint(checkpoint_dir_path / "dummy_final_enhanced.pt")
+        main_logger.info("Dummy checkpoint save/load test complete. Loaded epoch: %s", trainer_new.current_epoch)
 
     except Exception as e:
-        logger.error(f"Error in train_loop.py example: {e}", exc_info=True)
+        main_logger.error(f"Error in train_loop.py example: {e}", exc_info=True)
     finally:
         if checkpoint_dir_path.exists():
            shutil.rmtree(checkpoint_dir_path)
-           logger.info(f"Cleaned up dummy checkpoint directory: {checkpoint_dir_path}")
+           main_logger.info(f"Cleaned up dummy checkpoint directory: {checkpoint_dir_path}")
     
-    logger.info("train_loop.py example finished.")
+    main_logger.info("train_loop.py example finished.")


### PR DESCRIPTION
This commit establishes the framework for systematically benchmarking attention mechanisms (VanillaMHA, AHC, PAS, MoAE).

Key changes include:

1.  **Real Dataset Integration (WikiText-103):**
    - `data/wikitext103.py` now downloads and processes the actual WikiText-103 dataset, replacing the previous dummy data generation.

2.  **Enhanced Training & Evaluation Loop (`training/train_loop.py`):**
    - `Trainer` now calculates and logs training throughput (tokens/sec) and inference throughput (tokens/sec).
    - Peak GPU memory usage is logged more explicitly after training and validation phases of each epoch.
    - `Trainer.train()` returns a list of dictionaries containing detailed metrics for each epoch.

3.  **Structured Results Logging (`training/experiment_runner.py`):**
    - `experiment_runner.py` now processes the per-epoch metrics from `Trainer.train()`.
    - It saves these metrics, along with key configuration parameters (e.g., attention type, model size, sequence length, attention-specific settings), into a single CSV file (`experiment_results/benchmark_results.csv`) for easy aggregation and analysis.

4.  **Benchmark Configuration Files (`configs/benchmarking/`):**
    - Created 16 benchmark configuration files covering all 4 attention types (VanillaMHA, AHC, PAS, MoAE) and 4 sequence lengths (512, 1024, 2048, 4096).
    - These configs use consistent base model parameters for fair comparison and include heuristically adjusted batch sizes for longer sequences.

5.  **Benchmarking Scripts (`benchmarking/`):**
    - `evaluate_perplexity.py`: Marked as a placeholder for future dedicated test set evaluation.
    - `measure_speed_memory.py`: Updated with a basic structure (arg parsing, main function with TODOs) for future development as a standalone script for detailed inference performance analysis.

This framework enables running and collecting results for the planned benchmarking phase.